### PR TITLE
[GraphQL Client] Add staging

### DIFF
--- a/crates/sui-graphql-client/build.rs
+++ b/crates/sui-graphql-client/build.rs
@@ -1,5 +1,10 @@
 /// Register Sui RPC schema for creating structs for queries
 fn main() {
+    #[cfg(feature = "staging")]
+    cynic_codegen::register_schema("rpc")
+        .from_sdl_file("schema/graphql_rpc_staging.graphql")
+        .expect("Failed to find GraphQL Schema");
+    #[cfg(not(feature = "staging"))]
     cynic_codegen::register_schema("rpc")
         .from_sdl_file("schema/graphql_rpc.graphql")
         .expect("Failed to find GraphQL Schema");


### PR DESCRIPTION
I am thinking of how to handle incoming changes to the schema, and how we can have the CI catch them. 

I think we probably need to have a nightly CI that runs two things (might be wrong, still thinking how to go about this)
* compares the staging file that exists in this repo to the one in GraphQL crate
* runs the existing tests against  staging file to catch any changes in the live network that perhaps we missed?

However, this breaks the `Makefile` and `cargo nextest run --all-features`. The way I thought about it is that we need a test for stable, and a test run for staging. Need to think probably more about how to support staging / how to test mutually exclusive features.