### PR TITLE
Add dynamic fields query

### DIFF
--- a/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
+++ b/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
@@ -1,0 +1,198 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use base64ct::Encoding;
+use sui_types::types::TypeTag;
+
+use crate::query_types::schema;
+use crate::query_types::Address;
+use crate::query_types::Base64;
+use crate::query_types::JsonValue;
+use crate::query_types::MoveObjectContents;
+use crate::query_types::MoveValue;
+use crate::query_types::PageInfo;
+use crate::DynamicFieldOutput;
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema = "rpc",
+    graphql_type = "Query",
+    variables = "DynamicFieldConnectionArgs"
+)]
+pub struct DynamicFieldsOwnerQuery {
+    #[arguments(address: $address)]
+    pub owner: Option<ObjectOwner>,
+}
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema = "rpc",
+    graphql_type = "Owner",
+    variables = "DynamicFieldConnectionArgs"
+)]
+pub struct ObjectOwner {
+    #[arguments(after: $after, before: $before, first: $first, last: $last)]
+    pub dynamic_fields: DynamicFieldConnection,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "Query", variables = "DynamicFieldArgs")]
+pub struct DynamicFieldQuery {
+    #[arguments(address: $address)]
+    pub object: Option<ObjectField>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema = "rpc",
+    graphql_type = "Object",
+    variables = "DynamicFieldArgs"
+)]
+pub struct ObjectField {
+    #[arguments(name: $name)]
+    pub dynamic_field: Option<DynamicField>,
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct DynamicFieldArgs {
+    pub address: Address,
+    pub name: DynamicFieldName,
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct DynamicFieldsQueryArgs {
+    pub address: Address,
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct DynamicFieldConnectionArgs<'a> {
+    pub address: Address,
+    pub after: Option<&'a str>,
+    pub before: Option<&'a str>,
+    pub first: Option<i32>,
+    pub last: Option<i32>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "DynamicFieldConnection")]
+pub struct DynamicFieldConnection {
+    pub nodes: Vec<DynamicField>,
+    pub page_info: PageInfo,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "DynamicField")]
+pub struct DynamicField {
+    pub value: Option<DynamicFieldValue>,
+    pub name: Option<MoveValue>,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+#[cynic(schema = "rpc", graphql_type = "DynamicFieldValue")]
+pub enum DynamicFieldValue {
+    MoveObject(MoveObjectContents),
+    MoveValue(MoveValue),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(cynic::InputObject, Debug)]
+#[cynic(schema = "rpc", graphql_type = "DynamicFieldName")]
+pub struct DynamicFieldName {
+    #[cynic(rename = "type")]
+    pub type_: String,
+    pub bcs: Base64,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema = "rpc",
+    graphql_type = "Object",
+    variables = "DynamicFieldArgs"
+)]
+pub struct DynamicObjectField {
+    #[arguments(name: $name)]
+    pub dynamic_object_field: Option<DynamicField>,
+}
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "Query", variables = "DynamicFieldArgs")]
+pub struct DynamicObjectFieldQuery {
+    #[arguments(address: $address)]
+    pub object: Option<DynamicObjectField>,
+}
+
+impl DynamicFieldValue {
+    /// Returns the JSON representation of the field value, if available.
+    pub fn field_value_json(&self) -> Option<JsonValue> {
+        match self {
+            DynamicFieldValue::MoveObject(mo) => {
+                mo.contents.as_ref().and_then(|mv| mv.json.clone())
+            }
+            DynamicFieldValue::MoveValue(mv) => mv.json.clone(),
+            _ => None,
+        }
+    }
+
+    /// Return the typename and bcs of this dynamic field value.
+    pub fn type_bcs(&self) -> Option<(String, Vec<u8>)> {
+        match self {
+            DynamicFieldValue::MoveObject(mo) => mo
+                .contents
+                .as_ref()
+                .map(|o| (o.type_.repr.clone(), o.bcs.0.clone().into())),
+            DynamicFieldValue::MoveValue(mv) => {
+                Some((mv.type_.repr.clone(), mv.bcs.0.clone().into()))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl DynamicField {
+    /// Returns the JSON representation of the field value, if available.
+    pub fn field_value_json(&self) -> Option<JsonValue> {
+        self.value.as_ref().and_then(|v| v.field_value_json())
+    }
+}
+
+impl TryFrom<DynamicField> for DynamicFieldOutput {
+    type Error = anyhow::Error;
+
+    fn try_from(val: DynamicField) -> Result<Self, Self::Error> {
+        let typetag = TypeTag::from_str(
+            val.name
+                .as_ref()
+                .expect("There should be a name in this dynamic field")
+                .type_
+                .repr
+                .as_str(),
+        )
+        .map_err(|_| anyhow::anyhow!("Invalid TypeTag"))?;
+        Ok(DynamicFieldOutput {
+            name: crate::DynamicFieldName {
+                type_: typetag,
+                bcs: base64ct::Base64::decode_vec(val.name.as_ref().unwrap().bcs.0.as_ref())
+                    .unwrap(),
+                json: val.name.as_ref().unwrap().json.clone(),
+            },
+            value_as_json: val.field_value_json(),
+            value: val.value.and_then(|x| x.type_bcs()),
+        })
+    }
+}
+
+// impl From<DynamicField> for DynamicFieldOutput {
+//     fn from(val: DynamicField) -> DynamicFieldOutput {
+//         DynamicFieldOutput {
+//             name: crate::DynamicFieldName {
+//                 type_: TypeTag::from_str(val.name.as_ref().unwrap().type_.as_str()),
+//                 bcs: base64ct::Base64::decode_vec(val.name.as_ref().unwrap().bcs.0.as_ref())
+//                     .unwrap(),
+//                 json: val.name.as_ref().unwrap().json.clone(),
+//             },
+//             value_as_json: val.field_value_json(),
+//             value: val.value.and_then(|x| x.type_bcs()),
+//         }
+//     }
+// }

--- a/crates/sui-graphql-client/src/query_types/mod.rs
+++ b/crates/sui-graphql-client/src/query_types/mod.rs
@@ -7,6 +7,7 @@ mod chain;
 mod checkpoint;
 mod coin;
 mod dry_run;
+mod dynamic_fields;
 mod epoch;
 mod events;
 mod execute_tx;
@@ -38,6 +39,12 @@ pub use dry_run::DryRunArgs;
 pub use dry_run::DryRunQuery;
 pub use dry_run::DryRunResult;
 pub use dry_run::TransactionMetadata;
+pub use dynamic_fields::DynamicFieldArgs;
+pub use dynamic_fields::DynamicFieldConnectionArgs;
+pub use dynamic_fields::DynamicFieldName;
+pub use dynamic_fields::DynamicFieldQuery;
+pub use dynamic_fields::DynamicFieldsOwnerQuery;
+pub use dynamic_fields::DynamicObjectFieldQuery;
 pub use epoch::Epoch;
 pub use epoch::EpochSummaryArgs;
 pub use epoch::EpochSummaryQuery;
@@ -72,6 +79,7 @@ use sui_types::types::Address;
 
 use anyhow::anyhow;
 use cynic::impl_scalar;
+use serde_json::Value as JsonValue;
 
 #[cynic::schema("rpc")]
 pub mod schema {}
@@ -82,6 +90,7 @@ pub mod schema {}
 
 impl_scalar!(Address, schema::SuiAddress);
 impl_scalar!(u64, schema::UInt53);
+impl_scalar!(JsonValue, schema::JSON);
 
 #[derive(cynic::Scalar, Debug, Clone)]
 #[cynic(graphql_type = "Base64")]
@@ -111,6 +120,25 @@ pub struct MoveObject {
     pub bcs: Option<Base64>,
 }
 
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveObject")]
+pub struct MoveObjectContents {
+    pub contents: Option<MoveValue>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveValue")]
+pub struct MoveValue {
+    pub type_: MoveType,
+    pub bcs: Base64,
+    pub json: Option<JsonValue>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveType")]
+pub struct MoveType {
+    pub repr: String,
+}
 // ===========================================================================
 // Utility Types
 // ===========================================================================

--- a/crates/sui-graphql-client/src/query_types/object.rs
+++ b/crates/sui-graphql-client/src/query_types/object.rs
@@ -4,6 +4,7 @@
 use crate::query_types::schema;
 use crate::query_types::Address;
 use crate::query_types::Base64;
+use crate::query_types::MoveObjectContents;
 use crate::query_types::PageInfo;
 
 // ===========================================================================
@@ -50,6 +51,7 @@ pub struct ObjectsQueryArgs<'a> {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "Object")]
 pub struct Object {
+    pub as_move_object: Option<MoveObjectContents>,
     pub bcs: Option<Base64>,
 }
 


### PR DESCRIPTION
Added `dynamic_field`, `dynamic_object_field` and `dynamic_fields` queries to client. They all return a type that includes the `serde_json::Value` and `Object`. Also added a `dynamic_fields_on_wrapped_objects` function that uses the `owner` to query for dynamic fields. 

My understanding from the GraphQL code is that `MoveObject`'s bcs is the more generic `Object`, which should work just fine.

Finally, the last few changes ([3be26a8b](https://github.com/MystenLabs/sui-rust-sdk/pull/18/commits/3be26a8bf8c7cbe524e09b2c1299cd5965b68b11) and [43fbd400](https://github.com/MystenLabs/sui-rust-sdk/pull/18/commits/43fbd40058f980c6b811df82f276b76ec143957b)) were informed by integrating this `sui-sdk-types` and `sui-graphql-client` as dependencies in another project. The CLI there relies heavily on dynamic fields queries, on wrapped objects.