### PR TITLE
Fix events by making sender to 0x0 if it's null from the GQL query

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -310,40 +310,34 @@ impl Client {
 
     pub async fn events(
         &self,
+        filter: Option<EventFilter>,
         after: Option<String>,
         before: Option<String>,
-        filter: Option<EventFilter>,
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Option<Page<Event>>, Error> {
         let operation = EventsQuery::build(EventsQueryArgs {
+            filter,
             after,
             before,
-            filter,
             first,
             last,
         });
+
         let response = self.run_query(&operation).await?;
 
         if let Some(errors) = response.errors {
             return Err(Error::msg(format!("{:?}", errors)));
         }
 
-        // TODO bcs from bytes into Event fails due to custom type parser error
-        // called `Result::unwrap()` on an `Err` value: Custom("TypeParseError")
         if let Some(events) = response.data {
             let ec = events.events;
             let page_info = ec.page_info;
             let nodes = ec
                 .nodes
-                .iter()
-                .map(|e| base64ct::Base64::decode_vec(e.bcs.0.as_str()))
-                .collect::<Result<Vec<_>, base64ct::Error>>()
-                .map_err(|e| Error::msg(format!("Cannot decode Base64 event bcs bytes: {e}",)))?
-                .iter()
-                .map(|b| bcs::from_bytes::<Event>(b))
-                .collect::<Result<Vec<_>, bcs::Error>>()
-                .map_err(|e| Error::msg(format!("Cannot decode bcs bytes into Event: {e}",)))?;
+                .into_iter()
+                .map(Event::try_from)
+                .collect::<Result<Vec<Event>, _>>()?;
 
             Ok(Some(Page::new(page_info, nodes)))
         } else {
@@ -698,6 +692,23 @@ mod tests {
                 e.is_ok(),
                 "Epoch summary query failed for network: {n}. Error: {}",
                 e.unwrap_err()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_events_query() {
+        for (n, _) in NETWORKS {
+            let client = Client::new(n).unwrap();
+            let events = client.events(None, None, None, None, Some(10)).await;
+            assert!(
+                events.is_ok(),
+                "Events query failed for network: {n}. Error: {}",
+                events.unwrap_err()
+            );
+            assert!(
+                events.unwrap().is_some(),
+                "Events query returned no data for network: {n}"
             );
         }
     }

--- a/crates/sui-graphql-client/src/query_types/events.rs
+++ b/crates/sui-graphql-client/src/query_types/events.rs
@@ -1,6 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
+use base64ct::Encoding;
+use sui_types::types::{Identifier, ObjectId};
+
 use crate::query_types::{schema, Base64, PageInfo, SuiAddress};
 
 // ===========================================================================
@@ -20,9 +25,9 @@ pub struct EventsQuery {
 
 #[derive(cynic::QueryVariables, Debug)]
 pub struct EventsQueryArgs {
+    pub filter: Option<EventFilter>,
     pub after: Option<String>,
     pub before: Option<String>,
-    pub filter: Option<EventFilter>,
     pub first: Option<i32>,
     pub last: Option<i32>,
 }
@@ -38,12 +43,6 @@ pub struct EventConnection {
     pub nodes: Vec<Event>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "Event")]
-pub struct Event {
-    pub bcs: Base64,
-}
-
 #[derive(cynic::InputObject, Debug)]
 #[cynic(schema = "rpc", graphql_type = "EventFilter")]
 pub struct EventFilter {
@@ -51,4 +50,89 @@ pub struct EventFilter {
     pub event_type: Option<String>,
     pub sender: Option<SuiAddress>,
     pub transaction_digest: Option<String>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "Event")]
+pub struct Event {
+    #[cynic(rename = "type")]
+    pub type_: MoveType,
+    pub sending_module: Option<MoveModule>,
+    pub sender: Option<Address>,
+    pub bcs: Base64,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveModule")]
+pub struct MoveModule {
+    pub name: String,
+    pub package: MovePackage,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MovePackage")]
+pub struct MovePackage {
+    pub address: SuiAddress,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveType")]
+pub struct MoveType {
+    pub repr: Option<String>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "Address")]
+pub struct Address {
+    pub address: SuiAddress,
+}
+
+#[derive(cynic::Scalar, Debug, Clone)]
+pub struct MoveTypeLayout(pub String);
+
+impl TryFrom<Event> for sui_types::types::Event {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Event) -> Result<Self, Self::Error> {
+        let Event {
+            type_,
+            sending_module,
+            sender,
+            bcs,
+        } = value;
+
+        let type_ = if let Some(t) = type_
+            .repr
+            .map(|layout| sui_types::types::StructTag::from_str(&layout))
+            .transpose()
+            .map_err(|e| anyhow::anyhow!("Invalid struct tag in event: {}", e))?
+        {
+            t
+        } else {
+            return Err(anyhow::anyhow!("Missing struct tag in event"));
+        };
+
+        let (package_id, module) = sending_module
+            .map(|module| (module.package.address, module.name))
+            .ok_or_else(|| anyhow::anyhow!("Missing sending module in event"))?;
+        let package_id = ObjectId::from_str(&package_id.0)?;
+        let module = Identifier::from_str(&module)?;
+
+        let sender = sui_types::types::Address::from_str(
+            &sender
+                .map(|sender| sender.address.0)
+                .ok_or_else(|| anyhow::anyhow!("Missing sender address in event"))?,
+        )?;
+
+        let contents = base64ct::Base64::decode_vec(&bcs.0)
+            .map_err(|_| anyhow::anyhow!("Invalid base64 in event"))?;
+
+        Ok(Self {
+            package_id,
+            module,
+            sender,
+            type_,
+            contents,
+        })
+    }
 }

--- a/crates/sui-graphql-client/src/query_types/events.rs
+++ b/crates/sui-graphql-client/src/query_types/events.rs
@@ -118,11 +118,11 @@ impl TryFrom<Event> for sui_types::types::Event {
         let package_id = ObjectId::from_str(&package_id.0)?;
         let module = Identifier::from_str(&module)?;
 
-        let sender = sui_types::types::Address::from_str(
-            &sender
-                .map(|sender| sender.address.0)
-                .ok_or_else(|| anyhow::anyhow!("Missing sender address in event"))?,
-        )?;
+        let sender = sender
+            .map(|x| x.address)
+            .unwrap_or_else(|| SuiAddress("0x0".to_string()))
+            .try_into()
+            .map_err(|e| anyhow::anyhow!("Invalid sender address in event: {}", e))?;
 
         let contents = base64ct::Base64::decode_vec(&bcs.0)
             .map_err(|_| anyhow::anyhow!("Invalid base64 in event"))?;


### PR DESCRIPTION
GraphQL sets the sender to None if the event's sender is address 0x0. We make it back into 0x0 here to avoid making sender an optional field on Event.