### PR TITLE
chore: format with imports_granularity=Item

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: make check-features
 
       - name: rustfmt
-        run: cargo fmt -- --check
+        run: make check-fmt
 
       - name: clippy
         run: make clippy

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ check-features:
 
 .PHONY: check-fmt
 check-fmt:
-	cargo fmt -- --check
+	cargo fmt -- --config imports_granularity=Item --check
+
+.PHONY: fmt
+fmt:
+	cargo fmt -- --config imports_granularity=Item
 
 .PHONY: clippy
 clippy:

--- a/crates/sui-crypto/src/simple.rs
+++ b/crates/sui-crypto/src/simple.rs
@@ -1,6 +1,8 @@
-use crate::{SignatureError, SuiVerifier};
+use crate::SignatureError;
+use crate::SuiVerifier;
 use signature::Verifier;
-use sui_sdk_types::types::{SimpleSignature, UserSignature};
+use sui_sdk_types::types::SimpleSignature;
+use sui_sdk_types::types::UserSignature;
 
 pub struct SimpleVerifier;
 

--- a/crates/sui-crypto/src/zklogin/mod.rs
+++ b/crates/sui-crypto/src/zklogin/mod.rs
@@ -1,9 +1,15 @@
 use std::collections::HashMap;
 
-use crate::{SignatureError, SuiVerifier};
+use crate::SignatureError;
+use crate::SuiVerifier;
 use poseidon::POSEIDON;
 use signature::Verifier;
-use sui_sdk_types::types::{Claim, Jwk, JwkId, UserSignature, ZkLoginAuthenticator, ZkLoginInputs};
+use sui_sdk_types::types::Claim;
+use sui_sdk_types::types::Jwk;
+use sui_sdk_types::types::JwkId;
+use sui_sdk_types::types::UserSignature;
+use sui_sdk_types::types::ZkLoginAuthenticator;
+use sui_sdk_types::types::ZkLoginInputs;
 
 mod poseidon;
 mod verify;
@@ -130,7 +136,8 @@ struct JwtHeader {
 
 impl JwtHeader {
     fn from_base64(s: &str) -> Result<Self, SignatureError> {
-        use base64ct::{Base64UrlUnpadded, Encoding};
+        use base64ct::Base64UrlUnpadded;
+        use base64ct::Encoding;
 
         #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
         struct Header {

--- a/crates/sui-crypto/src/zklogin/poseidon/mod.rs
+++ b/crates/sui-crypto/src/zklogin/poseidon/mod.rs
@@ -9,7 +9,8 @@ use ark_bn254::Fr;
 use ark_ff::fields::Field;
 use ark_std::str::FromStr;
 use ark_std::Zero;
-use core::ops::{AddAssign, MulAssign};
+use core::ops::AddAssign;
+use core::ops::MulAssign;
 
 mod constants;
 

--- a/crates/sui-crypto/src/zklogin/verify.rs
+++ b/crates/sui-crypto/src/zklogin/verify.rs
@@ -403,7 +403,9 @@ fn big_int_array_to_bits<T: ToBits>(
     intended_size: usize,
 ) -> Result<Vec<u8>, SignatureError> {
     use itertools::Itertools;
-    use std::cmp::Ordering::{Equal, Greater, Less};
+    use std::cmp::Ordering::Equal;
+    use std::cmp::Ordering::Greater;
+    use std::cmp::Ordering::Less;
 
     integers
         .iter()

--- a/crates/sui-graphql-client/examples/custom_query.rs
+++ b/crates/sui-graphql-client/examples/custom_query.rs
@@ -4,10 +4,10 @@
 use anyhow::Result;
 use cynic::QueryBuilder;
 
-use sui_graphql_client::{
-    query_types::{schema, BigInt, Uint53},
-    Client,
-};
+use sui_graphql_client::query_types::schema;
+use sui_graphql_client::query_types::BigInt;
+use sui_graphql_client::query_types::Uint53;
+use sui_graphql_client::Client;
 
 // The data returned by the custom query.
 #[derive(cynic::QueryFragment, Debug)]

--- a/crates/sui-graphql-client/src/faucet.rs
+++ b/crates/sui-graphql-client/src/faucet.rs
@@ -1,14 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::types::{Address, ObjectId, TransactionDigest};
+use sui_types::types::Address;
+use sui_types::types::ObjectId;
+use sui_types::types::TransactionDigest;
 
-use anyhow::{anyhow, bail};
-use reqwest::{StatusCode, Url};
-use serde::{Deserialize, Serialize};
+use anyhow::anyhow;
+use anyhow::bail;
+use reqwest::StatusCode;
+use reqwest::Url;
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json::json;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::error;
+use tracing::info;
 
 pub const FAUCET_DEVNET_HOST: &str = "https://faucet.devnet.sui.io";
 pub const FAUCET_TESTNET_HOST: &str = "https://faucet.testnet.sui.io";

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -7,24 +7,63 @@ pub mod faucet;
 pub mod query_types;
 
 use base64ct::Encoding;
-use query_types::{
-    ActiveValidatorsArgs, ActiveValidatorsQuery, BalanceArgs, BalanceQuery, ChainIdentifierQuery,
-    CheckpointArgs, CheckpointId, CheckpointQuery, CoinMetadata, CoinMetadataArgs,
-    CoinMetadataQuery, EpochSummaryArgs, EpochSummaryQuery, EventFilter, EventsQuery,
-    EventsQueryArgs, ExecuteTransactionArgs, ExecuteTransactionQuery, ObjectFilter, ObjectQuery,
-    ObjectQueryArgs, ObjectsQuery, ObjectsQueryArgs, PageInfo, ProtocolConfigQuery,
-    ProtocolConfigs, ProtocolVersionArgs, ServiceConfig, ServiceConfigQuery, TransactionBlockArgs,
-    TransactionBlockQuery, TransactionBlocksQuery, TransactionBlocksQueryArgs, TransactionsFilter,
-    Uint53, Validator,
-};
+use query_types::ActiveValidatorsArgs;
+use query_types::ActiveValidatorsQuery;
+use query_types::BalanceArgs;
+use query_types::BalanceQuery;
+use query_types::ChainIdentifierQuery;
+use query_types::CheckpointArgs;
+use query_types::CheckpointId;
+use query_types::CheckpointQuery;
+use query_types::CoinMetadata;
+use query_types::CoinMetadataArgs;
+use query_types::CoinMetadataQuery;
+use query_types::EpochSummaryArgs;
+use query_types::EpochSummaryQuery;
+use query_types::EventFilter;
+use query_types::EventsQuery;
+use query_types::EventsQueryArgs;
+use query_types::ExecuteTransactionArgs;
+use query_types::ExecuteTransactionQuery;
+use query_types::ObjectFilter;
+use query_types::ObjectQuery;
+use query_types::ObjectQueryArgs;
+use query_types::ObjectsQuery;
+use query_types::ObjectsQueryArgs;
+use query_types::PageInfo;
+use query_types::ProtocolConfigQuery;
+use query_types::ProtocolConfigs;
+use query_types::ProtocolVersionArgs;
+use query_types::ServiceConfig;
+use query_types::ServiceConfigQuery;
+use query_types::TransactionBlockArgs;
+use query_types::TransactionBlockQuery;
+use query_types::TransactionBlocksQuery;
+use query_types::TransactionBlocksQueryArgs;
+use query_types::TransactionsFilter;
+use query_types::Uint53;
+use query_types::Validator;
 use reqwest::Url;
-use sui_types::types::{
-    framework::Coin, Address, CheckpointSequenceNumber, CheckpointSummary, Event, Object,
-    SignedTransaction, Transaction, TransactionEffects, UserSignature,
-};
+use sui_types::types::framework::Coin;
+use sui_types::types::Address;
+use sui_types::types::CheckpointSequenceNumber;
+use sui_types::types::CheckpointSummary;
+use sui_types::types::Event;
+use sui_types::types::Object;
+use sui_types::types::SignedTransaction;
+use sui_types::types::Transaction;
+use sui_types::types::TransactionEffects;
+use sui_types::types::UserSignature;
 
-use anyhow::{anyhow, ensure, Error, Result};
-use cynic::{serde, GraphQlResponse, MutationBuilder, Operation, QueryBuilder};
+use anyhow::anyhow;
+use anyhow::ensure;
+use anyhow::Error;
+use anyhow::Result;
+use cynic::serde;
+use cynic::GraphQlResponse;
+use cynic::MutationBuilder;
+use cynic::Operation;
+use cynic::QueryBuilder;
 use futures::Stream;
 use std::pin::Pin;
 
@@ -756,7 +795,11 @@ impl Client {
 mod tests {
     use futures::StreamExt;
 
-    use crate::{Client, DEVNET_HOST, LOCAL_HOST, MAINNET_HOST, TESTNET_HOST};
+    use crate::Client;
+    use crate::DEVNET_HOST;
+    use crate::LOCAL_HOST;
+    use crate::MAINNET_HOST;
+    use crate::TESTNET_HOST;
     const NETWORKS: [(&str, &str); 2] = [(MAINNET_HOST, "35834a8a"), (TESTNET_HOST, "4c78adac")];
 
     #[test]

--- a/crates/sui-graphql-client/src/query_types/active_validators.rs
+++ b/crates/sui-graphql-client/src/query_types/active_validators.rs
@@ -1,9 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::query_types::{
-    schema, Address, Base64, BigInt, MoveObject, PageInfo, SuiAddress, Uint53,
-};
+use crate::query_types::schema;
+use crate::query_types::Address;
+use crate::query_types::Base64;
+use crate::query_types::BigInt;
+use crate::query_types::MoveObject;
+use crate::query_types::PageInfo;
+use crate::query_types::SuiAddress;
+use crate::query_types::Uint53;
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(

--- a/crates/sui-graphql-client/src/query_types/balance.rs
+++ b/crates/sui-graphql-client/src/query_types/balance.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::SuiAddress;
-use crate::query_types::{schema, BigInt};
+use crate::query_types::schema;
+use crate::query_types::BigInt;
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "Query", variables = "BalanceArgs")]

--- a/crates/sui-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/sui-graphql-client/src/query_types/checkpoint.rs
@@ -4,10 +4,17 @@ use std::str::FromStr;
 
 use anyhow::Error;
 use chrono::DateTime as ChronoDT;
+use sui_types::types::CheckpointContentsDigest;
+use sui_types::types::CheckpointDigest;
+use sui_types::types::CheckpointSummary;
 use sui_types::types::GasCostSummary as NativeGasCostSummary;
-use sui_types::types::{CheckpointContentsDigest, CheckpointDigest, CheckpointSummary};
 
-use crate::query_types::{schema, Base64, BigInt, DateTime, Epoch, Uint53};
+use crate::query_types::schema;
+use crate::query_types::Base64;
+use crate::query_types::BigInt;
+use crate::query_types::DateTime;
+use crate::query_types::Epoch;
+use crate::query_types::Uint53;
 
 // ===========================================================================
 // Checkpoint Queries

--- a/crates/sui-graphql-client/src/query_types/coin.rs
+++ b/crates/sui-graphql-client/src/query_types/coin.rs
@@ -25,7 +25,9 @@ pub struct CoinMetadataArgs<'a> {
 // Types
 // ===========================================================================
 
-use crate::query_types::{schema, BigInt, Uint53};
+use crate::query_types::schema;
+use crate::query_types::BigInt;
+use crate::query_types::Uint53;
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "CoinMetadata")]

--- a/crates/sui-graphql-client/src/query_types/epoch.rs
+++ b/crates/sui-graphql-client/src/query_types/epoch.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 //
-use crate::query_types::{schema, BigInt, DateTime, SuiAddress, Uint53};
+use crate::query_types::schema;
+use crate::query_types::BigInt;
+use crate::query_types::DateTime;
+use crate::query_types::SuiAddress;
+use crate::query_types::Uint53;
 
 // ===========================================================================
 // Epoch Queries

--- a/crates/sui-graphql-client/src/query_types/events.rs
+++ b/crates/sui-graphql-client/src/query_types/events.rs
@@ -4,9 +4,13 @@
 use std::str::FromStr;
 
 use base64ct::Encoding;
-use sui_types::types::{Identifier, ObjectId};
+use sui_types::types::Identifier;
+use sui_types::types::ObjectId;
 
-use crate::query_types::{schema, Base64, PageInfo, SuiAddress};
+use crate::query_types::schema;
+use crate::query_types::Base64;
+use crate::query_types::PageInfo;
+use crate::query_types::SuiAddress;
 
 // ===========================================================================
 // Events Queries

--- a/crates/sui-graphql-client/src/query_types/execute_tx.rs
+++ b/crates/sui-graphql-client/src/query_types/execute_tx.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::query_types::{schema, Base64};
+use crate::query_types::schema;
+use crate::query_types::Base64;
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(

--- a/crates/sui-graphql-client/src/query_types/mod.rs
+++ b/crates/sui-graphql-client/src/query_types/mod.rs
@@ -15,28 +15,54 @@ mod protocol_config;
 mod service_config;
 mod transaction;
 
-pub use active_validators::{
-    ActiveValidatorsArgs, ActiveValidatorsQuery, EpochValidator, Validator, ValidatorConnection,
-    ValidatorSet,
-};
-use anyhow::{anyhow, Error};
-pub use balance::{Balance, BalanceArgs, BalanceQuery, Owner};
+pub use active_validators::ActiveValidatorsArgs;
+pub use active_validators::ActiveValidatorsQuery;
+pub use active_validators::EpochValidator;
+pub use active_validators::Validator;
+pub use active_validators::ValidatorConnection;
+pub use active_validators::ValidatorSet;
+use anyhow::anyhow;
+use anyhow::Error;
+pub use balance::Balance;
+pub use balance::BalanceArgs;
+pub use balance::BalanceQuery;
+pub use balance::Owner;
 pub use chain::ChainIdentifierQuery;
-pub use checkpoint::{CheckpointArgs, CheckpointId, CheckpointQuery};
-pub use coin::{CoinMetadata, CoinMetadataArgs, CoinMetadataQuery};
-pub use epoch::{Epoch, EpochSummaryArgs, EpochSummaryQuery};
-pub use events::{Event, EventConnection, EventFilter, EventsQuery, EventsQueryArgs};
-pub use execute_tx::{ExecuteTransactionArgs, ExecuteTransactionQuery, ExecutionResult};
-pub use object::{
-    ObjectFilter, ObjectKey, ObjectQuery, ObjectQueryArgs, ObjectsQuery, ObjectsQueryArgs,
-};
-pub use protocol_config::{ProtocolConfigQuery, ProtocolConfigs, ProtocolVersionArgs};
-pub use service_config::{Feature, ServiceConfig, ServiceConfigQuery};
+pub use checkpoint::CheckpointArgs;
+pub use checkpoint::CheckpointId;
+pub use checkpoint::CheckpointQuery;
+pub use coin::CoinMetadata;
+pub use coin::CoinMetadataArgs;
+pub use coin::CoinMetadataQuery;
+pub use epoch::Epoch;
+pub use epoch::EpochSummaryArgs;
+pub use epoch::EpochSummaryQuery;
+pub use events::Event;
+pub use events::EventConnection;
+pub use events::EventFilter;
+pub use events::EventsQuery;
+pub use events::EventsQueryArgs;
+pub use execute_tx::ExecuteTransactionArgs;
+pub use execute_tx::ExecuteTransactionQuery;
+pub use execute_tx::ExecutionResult;
+pub use object::ObjectFilter;
+pub use object::ObjectKey;
+pub use object::ObjectQuery;
+pub use object::ObjectQueryArgs;
+pub use object::ObjectsQuery;
+pub use object::ObjectsQueryArgs;
+pub use protocol_config::ProtocolConfigQuery;
+pub use protocol_config::ProtocolConfigs;
+pub use protocol_config::ProtocolVersionArgs;
+pub use service_config::Feature;
+pub use service_config::ServiceConfig;
+pub use service_config::ServiceConfigQuery;
 use sui_types::types::Address as NativeAddress;
-pub use transaction::{
-    TransactionBlockArgs, TransactionBlockQuery, TransactionBlocksQuery,
-    TransactionBlocksQueryArgs, TransactionsFilter,
-};
+pub use transaction::TransactionBlockArgs;
+pub use transaction::TransactionBlockQuery;
+pub use transaction::TransactionBlocksQuery;
+pub use transaction::TransactionBlocksQueryArgs;
+pub use transaction::TransactionsFilter;
 
 #[cynic::schema("rpc")]
 pub mod schema {}

--- a/crates/sui-graphql-client/src/query_types/object.rs
+++ b/crates/sui-graphql-client/src/query_types/object.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::query_types::{schema, Base64, PageInfo, SuiAddress, Uint53};
+use crate::query_types::schema;
+use crate::query_types::Base64;
+use crate::query_types::PageInfo;
+use crate::query_types::SuiAddress;
+use crate::query_types::Uint53;
 
 // ===========================================================================
 // Object(s) Queries

--- a/crates/sui-graphql-client/src/query_types/transaction.rs
+++ b/crates/sui-graphql-client/src/query_types/transaction.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::query_types::schema;
 use crate::query_types::Base64;
-use crate::query_types::{schema, PageInfo, SuiAddress, Uint53};
+use crate::query_types::PageInfo;
+use crate::query_types::SuiAddress;
+use crate::query_types::Uint53;
 
 // ===========================================================================
 // Transaction Block(s) Queries

--- a/crates/sui-sdk-types/src/hash.rs
+++ b/crates/sui-sdk-types/src/hash.rs
@@ -164,11 +164,19 @@ impl crate::types::MultisigCommittee {
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod type_digest {
     use super::Hasher;
-    use crate::types::{
-        CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSummary, Digest,
-        Object, ObjectDigest, Transaction, TransactionDigest, TransactionEffects,
-        TransactionEffectsDigest, TransactionEvents, TransactionEventsDigest,
-    };
+    use crate::types::CheckpointContents;
+    use crate::types::CheckpointContentsDigest;
+    use crate::types::CheckpointDigest;
+    use crate::types::CheckpointSummary;
+    use crate::types::Digest;
+    use crate::types::Object;
+    use crate::types::ObjectDigest;
+    use crate::types::Transaction;
+    use crate::types::TransactionDigest;
+    use crate::types::TransactionEffects;
+    use crate::types::TransactionEffectsDigest;
+    use crate::types::TransactionEvents;
+    use crate::types::TransactionEventsDigest;
 
     impl Object {
         pub fn digest(&self) -> ObjectDigest {

--- a/crates/sui-sdk-types/src/types/crypto/passkey.rs
+++ b/crates/sui-sdk-types/src/types/crypto/passkey.rs
@@ -1,6 +1,7 @@
 use crate::types::Digest;
 
-use super::{Secp256r1PublicKey, Secp256r1Signature};
+use super::Secp256r1PublicKey;
+use super::Secp256r1Signature;
 
 /// An passkey authenticator with parsed fields. See field defition below. Can be initialized from [struct RawPasskeyAuthenticator].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -290,7 +291,8 @@ impl proptest::arbitrary::Arbitrary for PasskeyAuthenticator {
     type Strategy = proptest::strategy::BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::{collection::vec, prelude::*};
+        use proptest::collection::vec;
+        use proptest::prelude::*;
         use serialization::ClientDataType;
         use serialization::CollectedClientData;
 

--- a/crates/sui-sdk-types/src/types/transaction/serialization.rs
+++ b/crates/sui-sdk-types/src/types/transaction/serialization.rs
@@ -1120,8 +1120,12 @@ mod signed_transaction {
 }
 
 mod transaction_expiration {
-    use crate::types::{EpochId, TransactionExpiration};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use crate::types::EpochId;
+    use crate::types::TransactionExpiration;
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serialize;
+    use serde::Serializer;
 
     #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
     #[serde(rename = "TransactionExpiration")]
@@ -1192,7 +1196,8 @@ mod transaction_expiration {
         }
 
         fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-            use schemars::schema::{Schema, SchemaObject};
+            use schemars::schema::Schema;
+            use schemars::schema::SchemaObject;
             schemars::schema::Schema::Object(schemars::schema::SchemaObject {
                 subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
                     one_of: Some(vec![


### PR DESCRIPTION
In an effort to reduce merge conflicts, run rustfmt with 'imports_granularity=Item' to have each imported item be on a separate line.