### PR TITLE
Use the new GraphQL schema + fix events to use the new bcs field

### DIFF
--- a/crates/sui-graphql-client/schema/graphql_rpc.graphql
+++ b/crates/sui-graphql-client/schema/graphql_rpc.graphql
@@ -168,7 +168,7 @@ enum AddressTransactionBlockRelationship {
 	`SENT` which behaves identically but is named more clearly. Both filters restrict
 	transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	SIGN
 	"""
@@ -176,9 +176,18 @@ enum AddressTransactionBlockRelationship {
 	"""
 	SENT
 	"""
-	Transactions that sent objects to this address.
+	Transactions that sent objects to this address. NOTE: this input filter has been deprecated
+	in favor of `AFFECTED`, which offers an easier to understand behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`AFFECTED` is introduced, whichever is later.
 	"""
 	RECV
+	"""
+	Transactions that this address was involved in, either as the sender, sponsor, or as the
+	owner of some object that was created, modified or transfered.
+	"""
+	AFFECTED
 }
 
 """
@@ -1196,7 +1205,42 @@ type Epoch {
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
 }
 
+type EpochConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EpochEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Epoch!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EpochEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Epoch!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 type Event {
+	"""
+	The transaction block that emitted this event. This information is only available for
+	events from indexed transactions, and not from transactions that have just been executed or
+	dry-run.
+	"""
+	transactionBlock: TransactionBlock
 	"""
 	The Move module containing some function that when called by
 	a programmable transaction block (PTB) emitted this event.
@@ -1214,32 +1258,13 @@ type Event {
 	"""
 	timestamp: DateTime
 	"""
-	The value's Move type.
+	The event's contents as a Move value.
 	"""
-	type: MoveType!
+	contents: MoveValue!
 	"""
-	The BCS representation of this value, Base64 encoded.
+	The Base64 encoded BCS serialized bytes of the event.
 	"""
 	bcs: Base64!
-	"""
-	Structured contents of a Move value.
-	"""
-	data: MoveData!
-	"""
-	Representation of a Move value in JSON, where:
-	
-	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
-	- Bools are represented by JSON boolean literals.
-	- u8, u16, and u32 are represented as JSON numbers.
-	- u64, u128, and u256 are represented as JSON strings.
-	- Vectors are represented by JSON arrays.
-	- Structs are represented by JSON objects.
-	- Empty optional values are represented by `null`.
-	
-	This form is offered as a less verbose convenience in cases where the layout of the type is
-	known by the client.
-	"""
-	json: JSON!
 }
 
 type EventConnection {
@@ -2350,6 +2375,10 @@ type MovePackage implements IObject & IOwner {
 	"""
 	typeOrigins: [TypeOrigin!]
 	"""
+	BCS representation of the package itself, as a MovePackage.
+	"""
+	packageBcs: Base64
+	"""
 	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
 	name, followed by module bytes), in alphabetic order by module name.
 	"""
@@ -2493,13 +2522,14 @@ type MoveType {
 	"""
 	signature: MoveTypeSignature!
 	"""
-	Structured representation of the "shape" of values that match this type.
+	Structured representation of the "shape" of values that match this type. May return no
+	layout if the type is invalid.
 	"""
-	layout: MoveTypeLayout!
+	layout: MoveTypeLayout
 	"""
-	The abilities this concrete type has.
+	The abilities this concrete type has. Returns no abilities if the type is invalid.
 	"""
-	abilities: [MoveAbility!]!
+	abilities: [MoveAbility!]
 }
 
 """
@@ -2518,11 +2548,11 @@ type MoveTypeLayout =
     }
   | { enum: [{
           type: string,
-          variants: [{ 
+          variants: [{
               name: string,
               fields: [{ name: string, layout: MoveTypeLayout }],
           }]
-      }] 
+      }]
   }
 """
 scalar MoveTypeLayout
@@ -2886,11 +2916,6 @@ enum ObjectKind {
 	The object is fetched from the index.
 	"""
 	INDEXED
-	"""
-	The object is deleted or wrapped and only partial information can be loaded from the
-	indexer.
-	"""
-	WRAPPED_OR_DELETED
 }
 
 """
@@ -3066,11 +3091,13 @@ type PageInfo {
 
 """
 If the object's owner is a Parent, this object is part of a dynamic field (it is the value of
-the dynamic field, or the intermediate Field object itself). Also note that if the owner
-is a parent, then it's guaranteed to be an object.
+the dynamic field, or the intermediate Field object itself), and it is owned by another object.
+
+Although its owner is guaranteed to be an object, it is exposed as an Owner, as the parent
+object could be wrapped and therefore not directly accessible.
 """
 type Parent {
-	parent: Object
+	parent: Owner
 }
 
 """
@@ -3301,6 +3328,7 @@ type Query {
 	`0x2::sui::SUI`). If no type is provided, it will default to `0x2::sui::SUI`.
 	"""
 	coins(first: Int, after: String, last: Int, before: String, type: String): CoinConnection!
+	epochs(first: Int, after: String, last: Int, before: String): EpochConnection!
 	"""
 	The checkpoints that exist in the network.
 	"""
@@ -4321,11 +4349,16 @@ input TransactionBlockFilter {
 	"""
 	beforeCheckpoint: UInt53
 	"""
+	Limit to transactions that interacted with the given address. The address could be a
+	sender, sponsor, or recipient of the transaction.
+	"""
+	affectedAddress: SuiAddress
+	"""
 	Limit to transactions that were sent by the given address. NOTE: this input filter has been
 	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
 	Both filters restrict transactions by their sender, only, not signers in general.
 	
-	This filter will be removed after 1.36.0 (2024-10-14).
+	This filter will be removed with 1.36.0 (2024-10-14).
 	"""
 	signAddress: SuiAddress
 	"""
@@ -4333,15 +4366,28 @@ input TransactionBlockFilter {
 	"""
 	sentAddress: SuiAddress
 	"""
-	Limit to transactions that sent an object to the given address.
+	Limit to transactions that sent an object to the given address. NOTE: this input filter has
+	been deprecated in favor of `affectedAddress` which offers an easier to understand
+	behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedAddress` is introduced, whichever is later.
 	"""
 	recvAddress: SuiAddress
 	"""
-	Limit to transactions that accepted the given object as an input.
+	Limit to transactions that accepted the given object as an input. NOTE: this input filter
+	has been deprecated in favor of `affectedObject` which offers an easier to under behavior.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	inputObject: SuiAddress
 	"""
-	Limit to transactions that output a versioon of this object.
+	Limit to transactions that output a versioon of this object. NOTE: this input filter has
+	been deprecated in favor of `affectedObject` which offers an easier to understand behavor.
+	
+	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
+	`affectedObject` is introduced, whichever is later.
 	"""
 	changedObject: SuiAddress
 	"""

--- a/crates/sui-graphql-client/schema/graphql_rpc.graphql
+++ b/crates/sui-graphql-client/schema/graphql_rpc.graphql
@@ -164,25 +164,9 @@ The possible relationship types for a transaction block: sent, or received.
 """
 enum AddressTransactionBlockRelationship {
 	"""
-	Transactions this address has sent. NOTE: this input filter has been deprecated in favor of
-	`SENT` which behaves identically but is named more clearly. Both filters restrict
-	transactions by their sender, only, not signers in general.
-	
-	This filter will be removed with 1.36.0 (2024-10-14).
-	"""
-	SIGN
-	"""
 	Transactions this address has sent.
 	"""
 	SENT
-	"""
-	Transactions that sent objects to this address. NOTE: this input filter has been deprecated
-	in favor of `AFFECTED`, which offers an easier to understand behavior.
-	
-	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
-	`AFFECTED` is introduced, whichever is later.
-	"""
-	RECV
 	"""
 	Transactions that this address was involved in, either as the sender, sponsor, or as the
 	owner of some object that was created, modified or transfered.
@@ -4226,7 +4210,7 @@ type TransactionBlock {
 	"""
 	expiration: Epoch
 	"""
-	Serialized form of this transaction's `SenderSignedData`, BCS serialized and Base64 encoded.
+	Serialized form of this transaction's `TransactionData`, BCS serialized and Base64 encoded.
 	"""
 	bcs: Base64
 }
@@ -4354,26 +4338,9 @@ input TransactionBlockFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
-	Limit to transactions that were sent by the given address. NOTE: this input filter has been
-	deprecated in favor of `sentAddress` which behaves identically but is named more clearly.
-	Both filters restrict transactions by their sender, only, not signers in general.
-	
-	This filter will be removed with 1.36.0 (2024-10-14).
-	"""
-	signAddress: SuiAddress
-	"""
 	Limit to transactions that were sent by the given address.
 	"""
 	sentAddress: SuiAddress
-	"""
-	Limit to transactions that sent an object to the given address. NOTE: this input filter has
-	been deprecated in favor of `affectedAddress` which offers an easier to understand
-	behavior.
-	
-	This filter will be removed with 1.36.0 (2024-10-14), or at least one release after
-	`affectedAddress` is introduced, whichever is later.
-	"""
-	recvAddress: SuiAddress
 	"""
 	Limit to transactions that accepted the given object as an input. NOTE: this input filter
 	has been deprecated in favor of `affectedObject` which offers an easier to under behavior.

--- a/crates/sui-graphql-client/src/query_types/events.rs
+++ b/crates/sui-graphql-client/src/query_types/events.rs
@@ -1,15 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr;
-
-use base64ct::Encoding;
-use sui_types::types::Identifier;
-
 use crate::query_types::schema;
 use crate::query_types::Address;
 use crate::query_types::Base64;
-use crate::query_types::GQLAddress;
 use crate::query_types::PageInfo;
 
 // ===========================================================================
@@ -59,74 +53,5 @@ pub struct EventFilter {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "Event")]
 pub struct Event {
-    #[cynic(rename = "type")]
-    pub type_: MoveType,
-    pub sending_module: Option<MoveModule>,
-    pub sender: Option<GQLAddress>,
     pub bcs: Base64,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveModule")]
-pub struct MoveModule {
-    pub name: String,
-    pub package: MovePackage,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MovePackage")]
-pub struct MovePackage {
-    pub address: Address,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveType")]
-pub struct MoveType {
-    pub repr: Option<String>,
-}
-
-#[derive(cynic::Scalar, Debug, Clone)]
-pub struct MoveTypeLayout(pub String);
-
-impl TryFrom<Event> for sui_types::types::Event {
-    type Error = anyhow::Error;
-
-    fn try_from(value: Event) -> Result<Self, Self::Error> {
-        let Event {
-            type_,
-            sending_module,
-            sender,
-            bcs,
-        } = value;
-
-        let type_ = if let Some(t) = type_
-            .repr
-            .map(|layout| sui_types::types::StructTag::from_str(&layout))
-            .transpose()
-            .map_err(|e| anyhow::anyhow!("Invalid struct tag in event: {}", e))?
-        {
-            t
-        } else {
-            return Err(anyhow::anyhow!("Missing struct tag in event"));
-        };
-
-        let (package_id, module) = sending_module
-            .map(|module| (module.package.address, module.name))
-            .ok_or_else(|| anyhow::anyhow!("Missing sending module in event"))?;
-        let package_id = package_id.into();
-        let module = Identifier::from_str(&module)?;
-
-        let sender = sender.map(|x| x.address).unwrap_or_else(|| Address::ZERO);
-
-        let contents = base64ct::Base64::decode_vec(&bcs.0)
-            .map_err(|_| anyhow::anyhow!("Invalid base64 in event"))?;
-
-        Ok(Self {
-            package_id,
-            module,
-            sender,
-            type_,
-            contents,
-        })
-    }
 }

--- a/crates/sui-graphql-client/src/query_types/transaction.rs
+++ b/crates/sui-graphql-client/src/query_types/transaction.rs
@@ -90,11 +90,13 @@ pub enum TransactionBlockKindInput {
 pub struct TransactionsFilter<'a> {
     pub function: Option<String>,
     pub kind: Option<TransactionBlockKindInput>,
+    pub after_checkpoint: Option<u64>,
     pub at_checkpoint: Option<u64>,
     pub before_checkpoint: Option<u64>,
-    pub changed_object: Option<Address>,
+    pub affected_address: Option<Address>,
+    pub sent_address: Option<Address>,
     pub input_object: Option<Address>,
-    pub recv_address: Option<Address>,
+    pub changed_object: Option<Address>,
     pub transaction_ids: Option<Vec<&'a str>>,
 }
 


### PR DESCRIPTION
This PR updates to the latest GraphQL schema that was merged just today. The new schema added events' BCS and added packageBCS, among other things.

As this is not deployed yet on any network, I tried it with a local network and an example. 
```
    let client = Client::new_localhost();
    let events = client
        .events(None, None, None, None, Some(10))
        .await
        .unwrap();
```

```
sui-rust-sdk/target/debug/examples/events`
Event { package_id: ObjectId(Address("0x0000000000000000000000000000000000000000000000000000000000000003")), module: Identifier("sui_system"), sender: Address("0x0000000000000000000000000000000000000000000000000000000000000000"), type_: StructTag { address: Address("0x0000000000000000000000000000000000000000000000000000000000000003"), module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [145, 246, 223, 176, 49, 124, 168, 14, 194, 45, 69, 169, 132, 170, 2, 71, 165, 30, 199, 209, 27, 226, 8, 28, 75, 132, 248, 19, 79, 246, 141, 94, 239, 131, 175, 97, 26, 137, 124, 15, 57, 236, 179, 67, 239, 101, 42, 7, 177, 2, 161, 219, 251, 128, 15, 63, 220, 76, 195, 157, 147, 224, 121, 90, 239, 131, 175, 97, 26, 137, 124, 15, 57, 236, 179, 67, 239, 101, 42, 7, 177, 2, 161, 219, 251, 128, 15, 63, 220, 76, 195, 157, 147, 224, 121, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 57, 39, 140, 4, 0, 0] }
Event { package_id: ObjectId(Address("0x0000000000000000000000000000000000000000000000000000000000000003")), module: Identifier("sui_system"), sender: Address("0x0000000000000000000000000000000000000000000000000000000000000000"), type_: StructTag { address: Address("0x0000000000000000000000000000000000000000000000000000000000000003"), module: Identifier("validator"), name: Identifier("StakingRequestEvent"), type_params: [] }, contents: [101, 77, 209, 180, 168, 142, 4, 77, 126, 25, 146, 43, 45, 184, 217, 150, 21, 195, 27, 205, 197, 23, 180, 147, 76, 242, 208, 133, 174, 85, 201, 5, 125, 145, 0, 205, 210, 137, 247, 10, 224, 126, 183, 47, 152, 24, 97, 34, 19, 131, 250, 249, 98, 57, 207, 214, 220, 215, 242, 234, 203, 112, 29, 64, 125, 145, 0, 205, 210, 137, 247, 10, 224, 126, 183, 47, 152, 24, 97, 34, 19, 131, 250, 249, 98, 57, 207, 214, 220, 215, 242, 234, 203, 112, 29, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 57, 39, 140, 4, 0, 0] }
```