### PR TITLE
Fix transaction(s) query

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -775,12 +775,12 @@ impl Client {
         });
         let response = self.run_query(&operation).await?;
 
-        Ok(response
+        response
             .data
             .and_then(|d| d.transaction_block)
             .map(|tx| tx.try_into())
             .transpose()
-            .map_err(|e| Error::msg(format!("Cannot decode transaction: {e}")))?)
+            .map_err(|e| Error::msg(format!("Cannot decode transaction: {e}")))
     }
 
     /// Get a page of transactions based on the provided filters.

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -1117,6 +1117,20 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
+    async fn test_transactions_query() {
+        for (n, _) in NETWORKS {
+            let client = Client::new(n).unwrap();
+            let transactions = client.transactions(None, None, None, Some(5), None).await;
+            assert!(
+                transactions.is_ok(),
+                "Transactions query failed for network: {n}. Error: {}",
+                transactions.unwrap_err()
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn test_total_supply() {
         for (n, _) in NETWORKS {
             let client = Client::new(n).unwrap();

--- a/crates/sui-graphql-client/src/query_types/transaction.rs
+++ b/crates/sui-graphql-client/src/query_types/transaction.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Error;
+use base64ct::Encoding;
+use sui_types::types::SignedTransaction;
+use sui_types::types::Transaction;
+use sui_types::types::UserSignature;
+
 use crate::query_types::schema;
 use crate::query_types::Address;
 use crate::query_types::Base64;
@@ -42,12 +48,12 @@ pub struct TransactionBlockArgs {
 }
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct TransactionBlocksQueryArgs {
+pub struct TransactionBlocksQueryArgs<'a> {
     pub first: Option<i32>,
-    pub after: Option<String>,
+    pub after: Option<&'a str>,
     pub last: Option<i32>,
-    pub before: Option<String>,
-    pub filter: Option<TransactionsFilter>,
+    pub before: Option<&'a str>,
+    pub filter: Option<TransactionsFilter<'a>>,
 }
 
 // ===========================================================================
@@ -59,6 +65,7 @@ pub struct TransactionBlocksQueryArgs {
 pub struct TransactionBlock {
     pub bcs: Option<Base64>,
     pub effects: Option<TransactionBlockEffects>,
+    pub signatures: Option<Vec<Base64>>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -80,7 +87,7 @@ pub enum TransactionBlockKindInput {
 
 #[derive(cynic::InputObject, Debug)]
 #[cynic(schema = "rpc", graphql_type = "TransactionBlockFilter")]
-pub struct TransactionsFilter {
+pub struct TransactionsFilter<'a> {
     pub function: Option<String>,
     pub kind: Option<TransactionBlockKindInput>,
     pub at_checkpoint: Option<u64>,
@@ -88,6 +95,7 @@ pub struct TransactionsFilter {
     pub changed_object: Option<Address>,
     pub input_object: Option<Address>,
     pub recv_address: Option<Address>,
+    pub transaction_ids: Option<Vec<&'a str>>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -95,4 +103,37 @@ pub struct TransactionsFilter {
 pub struct TransactionBlockConnection {
     pub nodes: Vec<TransactionBlock>,
     pub page_info: PageInfo,
+}
+
+impl TryFrom<TransactionBlock> for SignedTransaction {
+    type Error = anyhow::Error;
+
+    fn try_from(value: TransactionBlock) -> Result<Self, Self::Error> {
+        let transaction = value
+            .bcs
+            .map(|tx| base64ct::Base64::decode_vec(tx.0.as_str()))
+            .transpose()
+            .map_err(|_| Error::msg("Cannot decode Base64 transaction bcs bytes"))?
+            .map(|bcs| bcs::from_bytes::<Transaction>(&bcs))
+            .transpose()
+            .map_err(|_| Error::msg("Cannot decode bcs bytes into Transaction"))?;
+
+        let signatures = if let Some(sigs) = value.signatures {
+            sigs.iter()
+                .map(|s| UserSignature::from_base64(&s.0))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::msg("Cannot decode Base64 signature"))?
+        } else {
+            vec![]
+        };
+
+        if let Some(transaction) = transaction {
+            Ok(SignedTransaction {
+                transaction,
+                signatures,
+            })
+        } else {
+            Err(Error::msg("Cannot decode transaction"))
+        }
+    }
 }


### PR DESCRIPTION
The `TransactionBlock` bcs in GraphQL now encodes the `TransactionData`. This PR fixes the logic to correctly deserialize the transaction bcs data and signatures into a `SignedTransaction`. 

As the service does not serve yet the new data, I tested it locally by starting a local network and GraphQL server. For now, I put an `#ignore` on the test.