### PR TITLE
[GraphQL Client] Add a pagination filter

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -73,7 +73,6 @@ use futures::Stream;
 use reqwest::Url;
 use std::pin::Pin;
 
-const ITEMS_PER_PAGE: i32 = 10;
 const MAINNET_HOST: &str = "https://sui-mainnet.mystenlabs.com/graphql";
 const TESTNET_HOST: &str = "https://sui-testnet.mystenlabs.com/graphql";
 const DEVNET_HOST: &str = "https://sui-devnet.mystenlabs.com/graphql";
@@ -128,8 +127,8 @@ pub enum Direction {
     Backward,
 }
 
-/// Pagination options for querying the GraphQL server. It defaults to forward pagination with a
-/// limit of 10 items per request.
+/// Pagination options for querying the GraphQL server. It defaults to forward pagination with the
+/// GraphQL server's default items per page limit.
 pub struct PaginationFilter<'a> {
     direction: Direction,
     cursor: Option<&'a str>,
@@ -141,7 +140,7 @@ impl Default for PaginationFilter<'_> {
         Self {
             direction: Direction::Forward,
             cursor: None,
-            limit: Some(ITEMS_PER_PAGE),
+            limit: None,
         }
     }
 }

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -73,6 +73,7 @@ use futures::Stream;
 use reqwest::Url;
 use std::pin::Pin;
 
+const ITEMS_PER_PAGE: i32 = 10;
 const MAINNET_HOST: &str = "https://sui-mainnet.mystenlabs.com/graphql";
 const TESTNET_HOST: &str = "https://sui-testnet.mystenlabs.com/graphql";
 const DEVNET_HOST: &str = "https://sui-devnet.mystenlabs.com/graphql";
@@ -140,7 +141,7 @@ impl Default for PaginationFilter<'_> {
         Self {
             direction: Direction::Forward,
             cursor: None,
-            limit: Some(10),
+            limit: Some(ITEMS_PER_PAGE),
         }
     }
 }

--- a/crates/sui-graphql-client/src/query_types/active_validators.rs
+++ b/crates/sui-graphql-client/src/query_types/active_validators.rs
@@ -21,10 +21,10 @@ pub struct ActiveValidatorsQuery {
 }
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct ActiveValidatorsArgs {
+pub struct ActiveValidatorsArgs<'a> {
     pub id: Option<u64>,
-    pub after: Option<String>,
-    pub before: Option<String>,
+    pub after: Option<&'a str>,
+    pub before: Option<&'a str>,
     pub first: Option<i32>,
     pub last: Option<i32>,
 }

--- a/crates/sui-graphql-client/src/query_types/events.rs
+++ b/crates/sui-graphql-client/src/query_types/events.rs
@@ -22,10 +22,10 @@ pub struct EventsQuery {
 // ===========================================================================
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct EventsQueryArgs {
+pub struct EventsQueryArgs<'a> {
     pub filter: Option<EventFilter>,
-    pub after: Option<String>,
-    pub before: Option<String>,
+    pub after: Option<&'a str>,
+    pub before: Option<&'a str>,
     pub first: Option<i32>,
     pub last: Option<i32>,
 }


### PR DESCRIPTION
This PR adds a pagination filter instead of explicitly requiring after/before/first/last, which was quite wrong. A user cannot pass a cursor randomly, it needs to come from a page information that was returned by GraphQL.