### PR TITLE
[CI+GraphQL] Download Sui binary for localnet running in the CI + have tests only run on localnet 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,6 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      postgres: # we need this postgres instance for running a local network with indexer and graphql
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgrespw
-          POSTGRES_DB: sui_indexer_v2
-          POSTGRES_HOST_AUTH_METHOD: trust
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
 
     steps:
       - name: Checkout repository
@@ -57,6 +42,55 @@ jobs:
 
       - name: rustdoc
         run: make doc
+
+  wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: rust version
+        run: |
+          rustc --version
+          cargo --version
+
+      - uses: taiki-e/install-action@wasm-pack
+
+      - name: Install clang
+        run: sudo apt-get install -y clang
+
+      - name: Run tests in wasm
+        run: make wasm
+
+
+  run_tests_on_network:
+    runs-on: ubuntu-latest
+    env:
+      EPOCH_DURATION_MS: 10000
+    services:
+      postgres: # we need this postgres instance for running a local network with indexer and graphql
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgrespw
+          POSTGRES_DB: sui_indexer_v2
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: rust version
+        run: |
+          rustc --version
+          cargo --version
 
       - name: Get Sui releases JSON file
         env:
@@ -86,28 +120,12 @@ jobs:
           echo "Downloading testnet binary from $testnet_url"
           wget -q $testnet_url -O $filename
           tar -zxvf $filename ./sui
-          ./sui start --force-regenesis --with-faucet --with-indexer --with-graphql --pg-port 5432 --pg-db-name sui_indexer_v2 --epoch-duration-ms 10000 &
+          ./sui start --force-regenesis --with-faucet --with-indexer --with-graphql --pg-port 5432 --pg-db-name sui_indexer_v2 --epoch-duration-ms $EPOCH_DURATION_MS &
 
       - name: Run tests that require local network (GraphQL Client and Tx Builder)
+        env:
+          NETWORK: "local" # other expected options are mainnet, testnet, or devnet
         run: |
+          sleep $((EPOCH_DURATION_MS / 1000)) # wait for the network to get to second epoch
           make test-with-localnet
   
-  wasm:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: rust version
-        run: |
-          rustc --version
-          cargo --version
-
-      - uses: taiki-e/install-action@wasm-pack
-
-      - name: Install clang
-        run: sudo apt-get install -y clang
-
-      - name: Run tests in wasm
-        run: make wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,12 @@ jobs:
           binary_os=""
           if [ $os == "Linux" ]; then
             binary_os="ubuntu"
-          elif [ $os == "macOS" ]; then
-            binary_os="macos-arm64"
           fi
           
-          testnet_url=$(cat releases.json | jq --arg os $binary_os '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os))' | jq  -csr '.[0] | .browser_download_url')
+          testnet_url=$(cat releases.json | jq --arg os $binary_os '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os)) | select(.name | contains("x86"))'| jq  -csr '.[0] | .browser_download_url')
           filename="sui-$binary_os.tar.gz"
           echo "Downloading testnet binary from $testnet_url"
-          wget $testnet_url -O $filename
+          wget -q $testnet_url -O $filename
           tar -zxvf $filename ./sui
           ./sui start --force-regenesis --with-faucet --with-indexer --with-faucet --pg-port 5432 --pg-db-name sui_indexer_v2 &
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   RUSTFLAGS: -Dwarnings
+  SUI_BINARY_VERSION: "1.35.1" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
 
 jobs:
   test:
@@ -42,6 +43,20 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-nextest
+
+      - name: Check if the schema file was modified but not the version needed for the Sui CLI binary
+        run: |
+          # we need to keep the version of the Sui binary to be the same as when this schema made it into testnet
+          # to do so we check if the schema file changed, and if the workflow file changed. If it did not, then 
+          SCHEMA_FILE_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q 'crates/sui-graphql-client/schema/graphql_rpc.graphql' && echo "true" || echo "false")
+          WORKFLOW_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q '.github/workflows/ci.yml' && echo "true" || echo "false")
+
+          if [ "$SCHEMA_FILE_CHANGED" = "true" ] && [ "$WORKFLOW_CHANGED" = "true" ]; then
+            echo "Both the specific file and the workflow file were changed."
+          else
+            echo "If you changed the GraphQL schema, make sure you set the correct Sui SUI_BINARY_VERSION the workflow file. This version should be the one at which this schema was deployed to testnet network."
+            exit 1  # If you want the job to fail if the conditions aren't met.
+          fi
 
       - name: feature compatibility
         run: make check-features
@@ -75,7 +90,9 @@ jobs:
             binary_os="ubuntu"
           fi
           
-          testnet_url=$(cat releases.json | jq --arg os $binary_os '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os)) | select(.name | contains("x86"))'| jq  -csr '.[0] | .browser_download_url')
+          # We need to set the exact binary version that corresponds to the schema used in this repository
+          # If you update schema, then you need to update this SUI_BINARY_VERSION as well
+          testnet_url=$(cat releases.json | jq --arg os $binary_os --arg version $SUI_BINARY_VERSION '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os)) | select(.name | contains("x86")) | select(.name | contains($version))'| jq  -csr '.[0] | .browser_download_url')
           filename="sui-$binary_os.tar.gz"
           echo "Downloading testnet binary from $testnet_url"
           wget -q $testnet_url -O $filename

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,6 @@ jobs:
           rustc --version
           cargo --version
       
-      - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-nextest
 
       - name: Get the Sui testnet binary and start a local network

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           echo "Downloading testnet binary from $testnet_url"
           wget -q $testnet_url -O $filename
           tar -zxvf $filename ./sui
-          ./sui start --force-regenesis --with-faucet --with-indexer --with-graphql --pg-port 5432 --pg-db-name sui_indexer_v2 &
+          ./sui start --force-regenesis --with-faucet --with-indexer --with-graphql --pg-port 5432 --pg-db-name sui_indexer_v2 --epoch-duration-ms 10000 &
 
       - name: Run tests that require local network
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres: # we need this postgres instance for running a local network with indexer and graphql
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgrespw
+          POSTGRES_DB: sui_indexer_v2
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
     steps:
       - name: Checkout repository
@@ -37,8 +52,29 @@ jobs:
       - name: clippy
         run: make clippy
 
-      - name: Run tests
+      - name: Run tests that do not require local network
         run: make test
+
+      - name: Get the latest Sui testnet binary and start a local network
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \ # auth request, otherwise there's only 60 requests per hour limit
+            -L -o releases.json \
+            https://api.github.com/repos/MystenLabs/sui/releases
+          binary_os="ubuntu"
+          testnet_url=$(cat releases.json | jq --arg os $binary_os '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os))' | jq  -csr '.[0] | .browser_download_url')
+          filename="sui-$binary_os.tar.gz"
+          echo "Downloading testnet binary from $testnet_url"
+          wget $testnet_url -O $filename
+          tar -zxvf $filename ./sui
+          ./sui start --force-regenesis --with-faucet --with-indexer --with-faucet --pg-port 5432 --pg-db-name sui_indexer_v2 &
+
+      - name: Run tests that require local network
+        run: |
+          make test-with-localnet
 
       - name: rustdoc
         run: make doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: clippy
         run: make clippy
 
-      - name: Run tests that do not require local network
+      - name: Run tests
         run: make test
 
       - name: rustdoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,28 +43,33 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-nextest
 
-      - name: feature compatibility
-        run: make check-features
-
-      - name: rustfmt
-        run: make check-fmt
-
-      - name: clippy
-        run: make clippy
-
-      - name: Run tests that do not require local network
-        run: make test
-
+      # - name: feature compatibility
+      #   run: make check-features
+      #
+      # - name: rustfmt
+      #   run: make check-fmt
+      #
+      # - name: clippy
+      #   run: make clippy
+      #
+      # - name: Run tests that do not require local network
+      #   run: make test
+      #
       - name: Get the latest Sui testnet binary and start a local network
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          curl \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \ 
-            -L -o releases.json https://api.github.com/repos/MystenLabs/sui/releases
-          testnet_url=$(cat releases.json | jq '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains("ubuntu"))' | jq  -csr '.[0] | .browser_download_url')
-          filename="sui.tar.gz"
+          os=${{runner.os}}
+          binary_os=""
+          if [ $os == "Linux" ]; then
+            binary_os="ubuntu"
+          elif [ $os == "macOS" ]; then
+            binary_os="macos-arm64"
+          fi
+          
+          testnet_url=$(cat releases.json | jq --arg os $binary_os '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os))' | jq  -csr '.[0] | .browser_download_url')
+          filename="sui-$binary_os.tar.gz"
           echo "Downloading testnet binary from $testnet_url"
           wget $testnet_url -O $filename
           tar -zxvf $filename ./sui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
         run: |
           rustc --version
           cargo --version
+      
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-nextest
 
       - name: Get Sui releases JSON file
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,18 @@ jobs:
       # - name: Run tests that do not require local network
       #   run: make test
       #
-      - name: Get the latest Sui testnet binary and start a local network
+      - name: Get releases JSON file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          curl \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -L -o releases.json \
+            https://api.github.com/repos/MystenLabs/sui/releases
+
+      - name: Get the latest Sui testnet binary and start a local network
         shell: bash
         run: |
           os=${{runner.os}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: rust version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,18 +43,18 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-nextest
 
-      # - name: feature compatibility
-      #   run: make check-features
-      #
-      # - name: rustfmt
-      #   run: make check-fmt
-      #
-      # - name: clippy
-      #   run: make clippy
-      #
-      # - name: Run tests that do not require local network
-      #   run: make test
-      #
+      - name: feature compatibility
+        run: make check-features
+
+      - name: rustfmt
+        run: make check-fmt
+
+      - name: clippy
+        run: make clippy
+
+      - name: Run tests that do not require local network
+        run: make test
+
       - name: Get releases JSON file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run tests that require local network (GraphQL Client and Tx Builder)
         env:
-          NETWORK: "local" # other expected options are mainnet, testnet, or devnet
+          NETWORK: "local" # other expected options are mainnet, testnet, or devnet, or an actual URL to a GraphQL server: http://localhost:port
         run: |
           sleep $((EPOCH_DURATION_MS / 1000)) # wait for the network to get to second epoch
           make test-with-localnet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run tests that do not require local network
         run: make test
-      
+
       - name: rustdoc
         run: make doc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: rust version
         run: |
@@ -56,8 +54,11 @@ jobs:
 
       - name: Run tests that do not require local network
         run: make test
+      
+      - name: rustdoc
+        run: make doc
 
-      - name: Get releases JSON file
+      - name: Get Sui releases JSON file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -68,11 +69,12 @@ jobs:
             -L -o releases.json \
             https://api.github.com/repos/MystenLabs/sui/releases
 
-      - name: Get the latest Sui testnet binary and start a local network
+      - name: Get the Sui testnet binary and start a local network
         shell: bash
         env:
           SUI_BINARY_VERSION: "1.35.1" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
         run: |
+          echo "Sui binary version: $SUI_BINARY_VERSION"
           os=${{runner.os}}
           binary_os=""
           if [ $os == "Linux" ]; then
@@ -86,13 +88,10 @@ jobs:
           tar -zxvf $filename ./sui
           ./sui start --force-regenesis --with-faucet --with-indexer --with-graphql --pg-port 5432 --pg-db-name sui_indexer_v2 --epoch-duration-ms 10000 &
 
-      - name: Run tests that require local network
+      - name: Run tests that require local network (GraphQL Client and Tx Builder)
         run: |
           make test-with-localnet
-
-      - name: rustdoc
-        run: make doc
-
+  
   wasm:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,15 @@ jobs:
       - name: Check if the schema file was modified but not the version needed for the Sui CLI binary
         run: |
           # we need to keep the version of the Sui binary to be the same as when this schema made it into testnet
-          # to do so we check if the schema file changed, and if the workflow file changed. If it did not, then 
+          # to do so we check if the schema file changed, and if the workflow file changed. If it did not, then error 
           SCHEMA_FILE_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q 'crates/sui-graphql-client/schema/graphql_rpc.graphql' && echo "true" || echo "false")
           WORKFLOW_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q '.github/workflows/ci.yml' && echo "true" || echo "false")
+          echo $SCHEMA_FILE_CHANGED
+          echo $WORKFLOW_CHANGED
 
-          if [ "$SCHEMA_FILE_CHANGED" = "true" ] && [ "$WORKFLOW_CHANGED" = "true" ]; then
-            echo "Both the specific file and the workflow file were changed."
-          else
+          if [ "$SCHEMA_FILE_CHANGED" = "true" ] && [ "$WORKFLOW_CHANGED" = "false" ]; then
             echo "If you changed the GraphQL schema, make sure you set the correct Sui SUI_BINARY_VERSION the workflow file. This version should be the one at which this schema was deployed to testnet network."
-            exit 1  # If you want the job to fail if the conditions aren't met.
+            exit 1  
           fi
 
       - name: feature compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           echo "Downloading testnet binary from $testnet_url"
           wget -q $testnet_url -O $filename
           tar -zxvf $filename ./sui
-          ./sui start --force-regenesis --with-faucet --with-indexer --with-faucet --pg-port 5432 --pg-db-name sui_indexer_v2 &
+          ./sui start --force-regenesis --with-faucet --with-indexer --with-graphql --pg-port 5432 --pg-db-name sui_indexer_v2 &
 
       - name: Run tests that require local network
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,40 +95,25 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-nextest
 
-      - name: Get Sui releases JSON file
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          curl \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -L -o releases.json \
-            https://api.github.com/repos/MystenLabs/sui/releases
-
       - name: Get the Sui testnet binary and start a local network
         shell: bash
         env:
           SUI_BINARY_VERSION: "1.35.1" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
+          SUI_NETWORK_RELEASE: "testnet" # which release to use
         run: |
-          echo "Sui binary version: $SUI_BINARY_VERSION"
-          os=${{runner.os}}
-          binary_os=""
-          if [ $os == "Linux" ]; then
-            binary_os="ubuntu"
-          fi
+          ASSET_NAME="sui-$SUI_NETWORK_RELEASE-v$SUI_BINARY_VERSION-ubuntu-x86_64.tgz"
+          download_url="https://github.com/mystenlabs/sui/releases/download/$SUI_NETWORK_RELEASE-v$SUI_BINARY_VERSION/$ASSET_NAME"
           
-          testnet_url=$(cat releases.json | jq --arg os $binary_os --arg version $SUI_BINARY_VERSION '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os)) | select(.name | contains("x86")) | select(.name | contains($version))'| jq  -csr '.[0] | .browser_download_url')
-          filename="sui-$binary_os.tar.gz"
-          echo "Downloading testnet binary from $testnet_url"
-          wget -q $testnet_url -O $filename
-          tar -zxvf $filename ./sui
+          echo "Downloading testnet binary from $download_url"
+          wget -q $download_url -O sui.tgz
+          tar -zxvf sui.tgz ./sui
+          echo "Starting local network with a faucet, an indexer (port 5432) and GraphQL. Epoch duration is set to $EPOCH_DURATION_MS ms"
           ./sui start --force-regenesis --with-faucet --with-indexer --with-graphql --pg-port 5432 --pg-db-name sui_indexer_v2 --epoch-duration-ms $EPOCH_DURATION_MS &
 
       - name: Run tests that require local network (GraphQL Client and Tx Builder)
         env:
           NETWORK: "local" # other expected options are mainnet, testnet, or devnet, or an actual URL to a GraphQL server: http://localhost:port
         run: |
-          sleep $((EPOCH_DURATION_MS / 1000)) # wait for the network to get to second epoch
+          sleep $((EPOCH_DURATION_MS / 1000)) # wait for the network to get to epoch #2
           make test-with-localnet
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,10 @@ jobs:
         run: |
           curl \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \ # auth request, otherwise there's only 60 requests per hour limit
-            -L -o releases.json \
-            https://api.github.com/repos/MystenLabs/sui/releases
-          binary_os="ubuntu"
-          testnet_url=$(cat releases.json | jq --arg os $binary_os '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os))' | jq  -csr '.[0] | .browser_download_url')
-          filename="sui-$binary_os.tar.gz"
+            -H "Authorization: Bearer $GITHUB_TOKEN" \ 
+            -L -o releases.json https://api.github.com/repos/MystenLabs/sui/releases
+          testnet_url=$(cat releases.json | jq '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains("ubuntu"))' | jq  -csr '.[0] | .browser_download_url')
+          filename="sui.tar.gz"
           echo "Downloading testnet binary from $testnet_url"
           wget $testnet_url -O $filename
           tar -zxvf $filename ./sui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: make wasm
 
 
-  run_tests_on_network:
+  run_tests_with_network:
     runs-on: ubuntu-latest
     env:
       EPOCH_DURATION_MS: 10000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   RUSTFLAGS: -Dwarnings
-  SUI_BINARY_VERSION: "1.35.1" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
 
 jobs:
   test:
@@ -46,20 +45,6 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@cargo-nextest
 
-      - name: Check if the schema file was modified but not the version needed for the Sui CLI binary
-        run: |
-          # we need to keep the version of the Sui binary to be the same as when this schema made it into testnet
-          # to do so we check if the schema file changed, and if the workflow file changed. If it did not, then error 
-          SCHEMA_FILE_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q 'crates/sui-graphql-client/schema/graphql_rpc.graphql' && echo "true" || echo "false")
-          WORKFLOW_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q '.github/workflows/ci.yml' && echo "true" || echo "false")
-          echo $SCHEMA_FILE_CHANGED
-          echo $WORKFLOW_CHANGED
-
-          if [ "$SCHEMA_FILE_CHANGED" = "true" ] && [ "$WORKFLOW_CHANGED" = "false" ]; then
-            echo "If you changed the GraphQL schema, make sure you set the correct Sui SUI_BINARY_VERSION the workflow file. This version should be the one at which this schema was deployed to testnet network."
-            exit 1  
-          fi
-
       - name: feature compatibility
         run: make check-features
 
@@ -85,6 +70,8 @@ jobs:
 
       - name: Get the latest Sui testnet binary and start a local network
         shell: bash
+        env:
+          SUI_BINARY_VERSION: "1.35.1" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
         run: |
           os=${{runner.os}}
           binary_os=""
@@ -92,8 +79,6 @@ jobs:
             binary_os="ubuntu"
           fi
           
-          # We need to set the exact binary version that corresponds to the schema used in this repository
-          # If you update schema, then you need to update this SUI_BINARY_VERSION as well
           testnet_url=$(cat releases.json | jq --arg os $binary_os --arg version $SUI_BINARY_VERSION '.[] | .assets[] | select(.name | contains("testnet")) | select(.name | contains($os)) | select(.name | contains("x86")) | select(.name | contains($version))'| jq  -csr '.[0] | .browser_download_url')
           filename="sui-$binary_os.tar.gz"
           echo "Downloading testnet binary from $testnet_url"

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,12 @@ clippy:
 
 .PHONY: test
 test:
-	cargo nextest run --all-features
+	cargo nextest run --all-features -p sui-sdk-types -p sui-crypto
 	cargo test --doc
+
+.PHONY: test-with-localnet
+test-with-localnet:
+	cargo nextest run -p sui-graphql-client
 
 .PHONY: wasm
 wasm:

--- a/crates/sui-graphql-client/README.md
+++ b/crates/sui-graphql-client/README.md
@@ -20,7 +20,7 @@ executing transactions and more.
 ## Connecting to a GraphQL server
 Instantiate a client with [`Client::new(server: &str)`] or use one of the predefined functions for different networks [`Client`].
 
-```rust
+```rust, no_run
 use sui_graphql_client::Client;
 use anyhow::Result;
 
@@ -118,7 +118,7 @@ The generated query types are defined below. Note that the `id` variable is opti
 Note that instead of using `Uint53`, the scalar is mapped to `u64` in the library using `impl_scalar(u64, schema::Uint53)`, thus all references to `Uint53` in the schema are replaced with `u64` in the code below.
 
 
-```rust,ignore
+```rust, ignore
 #[derive(cynic::QueryVariables, Debug)]
 pub struct CustomQueryVariables {
     pub id: Option<u64>,
@@ -145,7 +145,7 @@ pub struct BigInt(pub String);
 ```
 
 The complete example is shown below:
-```rust
+```rust, ignore
 use anyhow::Result;
 use cynic::QueryBuilder;
 

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -939,12 +939,6 @@ mod tests {
     use crate::LOCAL_HOST;
     use crate::MAINNET_HOST;
     use crate::TESTNET_HOST;
-    const NETWORKS: [(&str, &str); 4] = [
-        (MAINNET_HOST, "35834a8a"),
-        (TESTNET_HOST, "4c78adac"),
-        (DEVNET_HOST, "_"),
-        (LOCAL_HOST, "_"),
-    ];
 
     #[test]
     fn test_rpc_server() {
@@ -963,243 +957,203 @@ mod tests {
 
     #[tokio::test]
     async fn test_balance_query() {
-        for (n, _) in NETWORKS.iter() {
-            let client = Client::new(n).unwrap();
-            let balance = client.balance("0x1".parse().unwrap(), None).await;
-            assert!(balance.is_ok(), "Balance query failed for network: {n}");
-        }
+        let client = Client::new_localhost();
+        let balance = client.balance("0x1".parse().unwrap(), None).await;
+        assert!(balance.is_ok(), "Balance query failed local network");
     }
 
     #[tokio::test]
     async fn test_chain_id() {
-        for (n, id) in NETWORKS[..2].iter() {
-            let client = Client::new(n).unwrap();
-            let chain_id = client.chain_id().await;
-            assert!(chain_id.is_ok());
-            assert_eq!(&chain_id.unwrap(), id);
-        }
+        let client = Client::new_localhost();
+        let chain_id = client.chain_id().await;
+        assert!(chain_id.is_ok());
     }
 
     #[tokio::test]
     async fn test_reference_gas_price_query() {
-        for (n, _) in NETWORKS.iter() {
-            let client = Client::new(n).unwrap();
-            let rgp = client.reference_gas_price(None).await;
-            assert!(
-                rgp.is_ok(),
-                "Reference gas price query failed for network: {n}"
-            );
-        }
+        let client = Client::new_localhost();
+        let rgp = client.reference_gas_price(None).await;
+        assert!(
+            rgp.is_ok(),
+            "Reference gas price query failed local network"
+        );
     }
 
     #[tokio::test]
     async fn test_protocol_config_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let pc = client.protocol_config(None).await;
-            assert!(pc.is_ok());
+        let client = Client::new_localhost();
+        let pc = client.protocol_config(None).await;
+        assert!(pc.is_ok());
 
-            // test specific version
-            let pc = client.protocol_config(Some(50)).await;
-            assert!(pc.is_ok());
-            let pc = pc.unwrap();
-            if let Some(pc) = pc {
-                assert_eq!(
-                    pc.protocol_version, 50,
-                    "Protocol version query mismatch for network: {n}. Expected: 50, received: {}",
-                    pc.protocol_version
-                );
-            }
+        // test specific version
+        let pc = client.protocol_config(Some(50)).await;
+        assert!(pc.is_ok());
+        let pc = pc.unwrap();
+        if let Some(pc) = pc {
+            assert_eq!(
+                pc.protocol_version, 50,
+                "Protocol version query mismatch local network. Expected: 50, received: {}",
+                pc.protocol_version
+            );
         }
     }
 
     #[tokio::test]
     async fn test_service_config_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let sc = client.service_config().await;
-            assert!(sc.is_ok(), "Service config query failed for network: {n}");
-        }
+        let client = Client::new_localhost();
+        let sc = client.service_config().await;
+        assert!(sc.is_ok(), "Service config query failed local network");
     }
 
     #[tokio::test]
     async fn test_active_validators() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let av = client
-                .active_validators(None, PaginationFilter::default())
-                .await;
-            assert!(
-                av.is_ok(),
-                "Active validators query failed for network: {n}. Error: {}",
-                av.unwrap_err()
-            );
+        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+        let client = Client::new_localhost();
+        let av = client.active_validators(None, None).await;
+        assert!(
+            av.is_ok(),
+            "Active validators query failed local network. Error: {}",
+            av.unwrap_err()
+        );
 
-            assert!(
-                !av.unwrap().is_empty(),
-                "Active validators query returned None for network: {n}"
-            );
-        }
+        assert!(
+            !av.unwrap().is_empty(),
+            "Active validators query returned None local network"
+        );
     }
 
     #[tokio::test]
     async fn test_coin_metadata_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let cm = client.coin_metadata("0x2::sui::SUI").await;
-            assert!(cm.is_ok(), "Coin metadata query failed for network: {n}");
-        }
+        let client = Client::new_localhost();
+        let cm = client.coin_metadata("0x2::sui::SUI").await;
+        assert!(cm.is_ok(), "Coin metadata query failed local network");
     }
 
     #[tokio::test]
     async fn test_checkpoint_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let c = client.checkpoint(None, None).await;
-            assert!(
-                c.is_ok(),
-                "Checkpoint query failed for network: {n}. Error: {}",
-                c.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let c = client.checkpoint(None, None).await;
+        assert!(
+            c.is_ok(),
+            "Checkpoint query failed local network. Error: {}",
+            c.unwrap_err()
+        );
     }
     #[tokio::test]
     async fn test_checkpoints_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let c = client.checkpoints(PaginationFilter::default()).await;
-            assert!(
-                c.is_ok(),
-                "Checkpoints query failed for network: {n}. Error: {}",
-                c.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let c = client.checkpoints(None, None, None, Some(5)).await;
+        assert!(
+            c.is_ok(),
+            "Checkpoints query failed local network. Error: {}",
+            c.unwrap_err()
+        );
     }
 
     #[tokio::test]
     async fn test_latest_checkpoint_sequence_number_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let last_checkpoint = client.latest_checkpoint_sequence_number().await;
-            assert!(
-                last_checkpoint.is_ok(),
-                "Latest checkpoint sequence number query failed for network: {n}. Error: {}",
-                last_checkpoint.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let last_checkpoint = client.latest_checkpoint_sequence_number().await;
+        assert!(
+            last_checkpoint.is_ok(),
+            "Latest checkpoint sequence number query failed local network. Error: {}",
+            last_checkpoint.unwrap_err()
+        );
     }
 
     #[tokio::test]
     async fn test_epoch_total_checkpoints_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let e = client.epoch_total_checkpoints(None).await;
-            assert!(
-                e.is_ok(),
-                "Epoch total checkpoints query failed for network: {n}. Error: {}",
-                e.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let e = client.epoch_total_checkpoints(None).await;
+        assert!(
+            e.is_ok(),
+            "Epoch total checkpoints query failed local network. Error: {}",
+            e.unwrap_err()
+        );
     }
 
     #[tokio::test]
     async fn test_epoch_total_transaction_blocks_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let e = client.epoch_total_transaction_blocks(None).await;
-            assert!(
-                e.is_ok(),
-                "Epoch total transaction blocks query failed for network: {n}. Error: {}",
-                e.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let e = client.epoch_total_transaction_blocks(None).await;
+        assert!(
+            e.is_ok(),
+            "Epoch total transaction blocks query failed local network. Error: {}",
+            e.unwrap_err()
+        );
     }
 
     #[tokio::test]
     async fn test_epoch_summary_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let e = client.epoch_summary(None).await;
-            assert!(
-                e.is_ok(),
-                "Epoch summary query failed for network: {n}. Error: {}",
-                e.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let e = client.epoch_summary(None).await;
+        assert!(
+            e.is_ok(),
+            "Epoch summary query failed local network. Error: {}",
+            e.unwrap_err()
+        );
     }
 
     #[tokio::test]
     #[ignore] // schema was updated, but the service has not been released with the new schema
     async fn test_events_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let events = client.events(None, PaginationFilter::default()).await;
-            assert!(
-                events.is_ok(),
-                "Events query failed for network: {n}. Error: {}",
-                events.unwrap_err()
-            );
-            assert!(
-                !events.unwrap().is_empty(),
-                "Events query returned no data for network: {n}"
-            );
-        }
+        let client = Client::new_localhost();
+        let events = client.events(None, None).await;
+        assert!(
+            events.is_ok(),
+            "Events query failed local network. Error: {}",
+            events.unwrap_err()
+        );
+        assert!(
+            !events.unwrap().is_empty(),
+            "Events query returned no data local network"
+        );
     }
 
     #[tokio::test]
     #[ignore]
     async fn test_objects_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let objects = client.objects(None, PaginationFilter::default()).await;
-            assert!(
-                objects.is_ok(),
-                "Objects query failed for network: {n}. Error: {}",
-                objects.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let objects = client.objects(None, None).await;
+        assert!(
+            objects.is_ok(),
+            "Objects query failed local network. Error: {}",
+            objects.unwrap_err()
+        );
     }
 
     #[tokio::test]
     #[ignore]
     async fn test_object_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let object = client.object("0x5".parse().unwrap(), None).await;
-            assert!(
-                object.is_ok(),
-                "Object query failed for network: {n}. Error: {}",
-                object.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let object = client.object("0x5".parse().unwrap(), None).await;
+        assert!(
+            object.is_ok(),
+            "Object query failed local network. Error: {}",
+            object.unwrap_err()
+        );
     }
 
     #[tokio::test]
     async fn test_object_bcs_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let object_bcs = client.object_bcs("0x5".parse().unwrap()).await;
-            assert!(
-                object_bcs.is_ok(),
-                "Object bcs query failed for network: {n}. Error: {}",
-                object_bcs.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let object_bcs = client.object_bcs("0x5".parse().unwrap()).await;
+        assert!(
+            object_bcs.is_ok(),
+            "Object bcs query failed local network. Error: {}",
+            object_bcs.unwrap_err()
+        );
     }
 
     #[tokio::test]
     async fn test_coins_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let coins = client
-                .coins("0x1".parse().unwrap(), None, PaginationFilter::default())
-                .await;
-            assert!(
-                coins.is_ok(),
-                "Coins query failed for network: {n}. Error: {}",
-                coins.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let coins = client.coins("0x1".parse().unwrap(), None, None).await;
+        assert!(
+            coins.is_ok(),
+            "Coins query failed local network. Error: {}",
+            coins.unwrap_err()
+        );
     }
 
     #[tokio::test]
@@ -1217,33 +1171,29 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_transactions_query() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let transactions = client.transactions(None, PaginationFilter::default()).await;
-            assert!(
-                transactions.is_ok(),
-                "Transactions query failed for network: {n}. Error: {}",
-                transactions.unwrap_err()
-            );
-        }
+        let client = Client::new_localhost();
+        let transactions = client.transactions(None, None).await;
+        assert!(
+            transactions.is_ok(),
+            "Transactions query failed local network. Error: {}",
+            transactions.unwrap_err()
+        );
     }
 
     #[tokio::test]
     async fn test_total_supply() {
-        for (n, _) in NETWORKS {
-            let client = Client::new(n).unwrap();
-            let ts = client.total_supply("0x2::sui::SUI").await;
-            assert!(
-                ts.is_ok(),
-                "Total supply query failed for network: {n}. Error: {}",
-                ts.unwrap_err()
-            );
-            assert_eq!(
-                ts.unwrap().unwrap(),
-                10_000_000_000,
-                "Total supply mismatch for network: {n}"
-            );
-        }
+        let client = Client::new_localhost();
+        let ts = client.total_supply("0x2::sui::SUI").await;
+        assert!(
+            ts.is_ok(),
+            "Total supply query failed local network. Error: {}",
+            ts.unwrap_err()
+        );
+        assert_eq!(
+            ts.unwrap().unwrap(),
+            10_000_000_000,
+            "Total supply mismatch local network"
+        );
     }
 
     #[tokio::test]

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -1031,7 +1031,9 @@ mod tests {
     #[tokio::test]
     async fn test_active_validators() {
         let client = test_client();
-        let av = client.active_validators(None, None).await;
+        let av = client
+            .active_validators(None, PaginationFilter::default())
+            .await;
         assert!(
             av.is_ok(),
             "Active validators query failed for {} network. Error: {}",
@@ -1071,7 +1073,7 @@ mod tests {
     #[tokio::test]
     async fn test_checkpoints_query() {
         let client = test_client();
-        let c = client.checkpoints(None, None, None, Some(5)).await;
+        let c = client.checkpoints(PaginationFilter::default()).await;
         assert!(
             c.is_ok(),
             "Checkpoints query failed for {} network. Error: {}",
@@ -1132,7 +1134,7 @@ mod tests {
     #[ignore] // schema was updated, but the service has not been released with the new schema
     async fn test_events_query() {
         let client = test_client();
-        let events = client.events(None, None).await;
+        let events = client.events(None, PaginationFilter::default()).await;
         assert!(
             events.is_ok(),
             "Events query failed for {} network. Error: {}",
@@ -1150,7 +1152,7 @@ mod tests {
     #[ignore]
     async fn test_objects_query() {
         let client = test_client();
-        let objects = client.objects(None, None).await;
+        let objects = client.objects(None, PaginationFilter::default()).await;
         assert!(
             objects.is_ok(),
             "Objects query failed for {} network. Error: {}",
@@ -1187,7 +1189,9 @@ mod tests {
     #[tokio::test]
     async fn test_coins_query() {
         let client = test_client();
-        let coins = client.coins("0x1".parse().unwrap(), None, None).await;
+        let coins = client
+            .coins("0x1".parse().unwrap(), None, PaginationFilter::default())
+            .await;
         assert!(
             coins.is_ok(),
             "Coins query failed for {} network. Error: {}",
@@ -1212,7 +1216,7 @@ mod tests {
     #[ignore]
     async fn test_transactions_query() {
         let client = test_client();
-        let transactions = client.transactions(None, None).await;
+        let transactions = client.transactions(None, PaginationFilter::default()).await;
         assert!(
             transactions.is_ok(),
             "Transactions query failed for {} network. Error: {}",

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -939,7 +939,12 @@ mod tests {
     use crate::LOCAL_HOST;
     use crate::MAINNET_HOST;
     use crate::TESTNET_HOST;
-    const NETWORKS: [(&str, &str); 2] = [(MAINNET_HOST, "35834a8a"), (TESTNET_HOST, "4c78adac")];
+    const NETWORKS: [(&str, &str); 4] = [
+        (MAINNET_HOST, "35834a8a"),
+        (TESTNET_HOST, "4c78adac"),
+        (DEVNET_HOST, "_"),
+        (LOCAL_HOST, "_"),
+    ];
 
     #[test]
     fn test_rpc_server() {
@@ -967,7 +972,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_chain_id() {
-        for (n, id) in NETWORKS.iter() {
+        for (n, id) in NETWORKS[..2].iter() {
             let client = Client::new(n).unwrap();
             let chain_id = client.chain_id().await;
             assert!(chain_id.is_ok());

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -931,27 +931,26 @@ impl Client {
 
 // This function is used in tests to create a new client instance for the local server.
 #[cfg(test)]
-fn test_client() -> Client {
-    let network = std::env::var("NETWORK").unwrap_or_else(|_| "local".to_string());
-    match network.as_str() {
-        "mainnet" => Client::new_mainnet(),
-        "testnet" => Client::new_testnet(),
-        "devnet" => Client::new_devnet(),
-        _ => Client::new_localhost(),
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use futures::StreamExt;
 
-    use crate::test_client;
     use crate::Client;
     use crate::PaginationFilter;
     use crate::DEVNET_HOST;
     use crate::LOCAL_HOST;
     use crate::MAINNET_HOST;
     use crate::TESTNET_HOST;
+
+    fn test_client() -> Client {
+        let network = std::env::var("NETWORK").unwrap_or_else(|_| "local".to_string());
+        match network.as_str() {
+            "mainnet" => Client::new_mainnet(),
+            "testnet" => Client::new_testnet(),
+            "devnet" => Client::new_devnet(),
+            "local" => Client::new_localhost(),
+            _ => Client::new(&network).expect("Invalid network URL: {network}"),
+        }
+    }
 
     #[test]
     fn test_rpc_server() {

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -959,7 +959,7 @@ mod tests {
     async fn test_balance_query() {
         let client = Client::new_localhost();
         let balance = client.balance("0x1".parse().unwrap(), None).await;
-        assert!(balance.is_ok(), "Balance query failed local network");
+        assert!(balance.is_ok(), "Balance query failed for local network");
     }
 
     #[tokio::test]
@@ -975,7 +975,7 @@ mod tests {
         let rgp = client.reference_gas_price(None).await;
         assert!(
             rgp.is_ok(),
-            "Reference gas price query failed local network"
+            "Reference gas price query failed for local network"
         );
     }
 
@@ -992,7 +992,7 @@ mod tests {
         if let Some(pc) = pc {
             assert_eq!(
                 pc.protocol_version, 50,
-                "Protocol version query mismatch local network. Expected: 50, received: {}",
+                "Protocol version query mismatch for local network. Expected: 50, received: {}",
                 pc.protocol_version
             );
         }
@@ -1002,7 +1002,7 @@ mod tests {
     async fn test_service_config_query() {
         let client = Client::new_localhost();
         let sc = client.service_config().await;
-        assert!(sc.is_ok(), "Service config query failed local network");
+        assert!(sc.is_ok(), "Service config query failed for local network");
     }
 
     #[tokio::test]
@@ -1012,13 +1012,13 @@ mod tests {
         let av = client.active_validators(None, None).await;
         assert!(
             av.is_ok(),
-            "Active validators query failed local network. Error: {}",
+            "Active validators query failed for local network. Error: {}",
             av.unwrap_err()
         );
 
         assert!(
             !av.unwrap().is_empty(),
-            "Active validators query returned None local network"
+            "Active validators query returned None for local network"
         );
     }
 
@@ -1026,7 +1026,7 @@ mod tests {
     async fn test_coin_metadata_query() {
         let client = Client::new_localhost();
         let cm = client.coin_metadata("0x2::sui::SUI").await;
-        assert!(cm.is_ok(), "Coin metadata query failed local network");
+        assert!(cm.is_ok(), "Coin metadata query failed for local network");
     }
 
     #[tokio::test]
@@ -1035,7 +1035,7 @@ mod tests {
         let c = client.checkpoint(None, None).await;
         assert!(
             c.is_ok(),
-            "Checkpoint query failed local network. Error: {}",
+            "Checkpoint query failed for local network. Error: {}",
             c.unwrap_err()
         );
     }
@@ -1045,7 +1045,7 @@ mod tests {
         let c = client.checkpoints(None, None, None, Some(5)).await;
         assert!(
             c.is_ok(),
-            "Checkpoints query failed local network. Error: {}",
+            "Checkpoints query failed for local network. Error: {}",
             c.unwrap_err()
         );
     }
@@ -1056,7 +1056,7 @@ mod tests {
         let last_checkpoint = client.latest_checkpoint_sequence_number().await;
         assert!(
             last_checkpoint.is_ok(),
-            "Latest checkpoint sequence number query failed local network. Error: {}",
+            "Latest checkpoint sequence number query failed for local network. Error: {}",
             last_checkpoint.unwrap_err()
         );
     }
@@ -1067,7 +1067,7 @@ mod tests {
         let e = client.epoch_total_checkpoints(None).await;
         assert!(
             e.is_ok(),
-            "Epoch total checkpoints query failed local network. Error: {}",
+            "Epoch total checkpoints query failed for local network. Error: {}",
             e.unwrap_err()
         );
     }
@@ -1078,7 +1078,7 @@ mod tests {
         let e = client.epoch_total_transaction_blocks(None).await;
         assert!(
             e.is_ok(),
-            "Epoch total transaction blocks query failed local network. Error: {}",
+            "Epoch total transaction blocks query failed for local network. Error: {}",
             e.unwrap_err()
         );
     }
@@ -1089,7 +1089,7 @@ mod tests {
         let e = client.epoch_summary(None).await;
         assert!(
             e.is_ok(),
-            "Epoch summary query failed local network. Error: {}",
+            "Epoch summary query failed for local network. Error: {}",
             e.unwrap_err()
         );
     }
@@ -1101,12 +1101,12 @@ mod tests {
         let events = client.events(None, None).await;
         assert!(
             events.is_ok(),
-            "Events query failed local network. Error: {}",
+            "Events query failed for local network. Error: {}",
             events.unwrap_err()
         );
         assert!(
             !events.unwrap().is_empty(),
-            "Events query returned no data local network"
+            "Events query returned no data for local network"
         );
     }
 
@@ -1117,7 +1117,7 @@ mod tests {
         let objects = client.objects(None, None).await;
         assert!(
             objects.is_ok(),
-            "Objects query failed local network. Error: {}",
+            "Objects query failed for local network. Error: {}",
             objects.unwrap_err()
         );
     }
@@ -1129,7 +1129,7 @@ mod tests {
         let object = client.object("0x5".parse().unwrap(), None).await;
         assert!(
             object.is_ok(),
-            "Object query failed local network. Error: {}",
+            "Object query failed for local network. Error: {}",
             object.unwrap_err()
         );
     }
@@ -1140,7 +1140,7 @@ mod tests {
         let object_bcs = client.object_bcs("0x5".parse().unwrap()).await;
         assert!(
             object_bcs.is_ok(),
-            "Object bcs query failed local network. Error: {}",
+            "Object bcs query failed for local network. Error: {}",
             object_bcs.unwrap_err()
         );
     }
@@ -1151,7 +1151,7 @@ mod tests {
         let coins = client.coins("0x1".parse().unwrap(), None, None).await;
         assert!(
             coins.is_ok(),
-            "Coins query failed local network. Error: {}",
+            "Coins query failed for local network. Error: {}",
             coins.unwrap_err()
         );
     }
@@ -1175,7 +1175,7 @@ mod tests {
         let transactions = client.transactions(None, None).await;
         assert!(
             transactions.is_ok(),
-            "Transactions query failed local network. Error: {}",
+            "Transactions query failed for local network. Error: {}",
             transactions.unwrap_err()
         );
     }
@@ -1186,13 +1186,13 @@ mod tests {
         let ts = client.total_supply("0x2::sui::SUI").await;
         assert!(
             ts.is_ok(),
-            "Total supply query failed local network. Error: {}",
+            "Total supply query failed for local network. Error: {}",
             ts.unwrap_err()
         );
         assert_eq!(
             ts.unwrap().unwrap(),
             10_000_000_000,
-            "Total supply mismatch local network"
+            "Total supply mismatch for local network"
         );
     }
 


### PR DESCRIPTION
This updates the CI to enable a local network to be run from a testnet sui binary. It also splits the makefile tests into two: one for those tests that do not require a network, and one for those that need, e.g., graphql-client and soon sui-transaction-builder.

Changed tests to run on a local network. That means that things can still break if the schema is updated without updating to the binary that contains the released schema, so if that happens often, we might want to add a check on that.