### PR TITLE
[GraphQL Client][DFS] Return Result<Page> instead of Result<Option<Page>>

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -715,7 +715,7 @@ impl Client {
         &self,
         address: Address,
         pagination_filter: PaginationFilter<'a>,
-    ) -> Result<Option<Page<DynamicFieldOutput>>, Error> {
+    ) -> Result<Page<DynamicFieldOutput>, Error> {
         let (after, before, first, last) = self.pagination_filter(pagination_filter);
         let operation = DynamicFieldsOwnerQuery::build(DynamicFieldConnectionArgs {
             address,
@@ -731,10 +731,10 @@ impl Client {
         }
 
         let Some(DynamicFieldsOwnerQuery { owner: Some(dfs) }) = response.data else {
-            return Ok(Some(Page::new_empty()));
+            return Ok(Page::new_empty());
         };
 
-        Ok(Some(Page::new(
+        Ok(Page::new(
             dfs.dynamic_fields.page_info,
             dfs.dynamic_fields
                 .nodes
@@ -742,7 +742,7 @@ impl Client {
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, Error>>()
                 .map_err(|e| Error::msg(format!("{:?}", e)))?,
-        )))
+        ))
     }
 
     // ===========================================================================

--- a/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
+++ b/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
@@ -181,18 +181,3 @@ impl TryFrom<DynamicField> for DynamicFieldOutput {
         })
     }
 }
-
-// impl From<DynamicField> for DynamicFieldOutput {
-//     fn from(val: DynamicField) -> DynamicFieldOutput {
-//         DynamicFieldOutput {
-//             name: crate::DynamicFieldName {
-//                 type_: TypeTag::from_str(val.name.as_ref().unwrap().type_.as_str()),
-//                 bcs: base64ct::Base64::decode_vec(val.name.as_ref().unwrap().bcs.0.as_ref())
-//                     .unwrap(),
-//                 json: val.name.as_ref().unwrap().json.clone(),
-//             },
-//             value_as_json: val.field_value_json(),
-//             value: val.value.and_then(|x| x.type_bcs()),
-//         }
-//     }
-// }


### PR DESCRIPTION
Align this function to have a similar return signature as all the other functions that return `Result<Page<T>>`.