### PR TITLE
[GraphQL][DF] Fix return of bcs and typetag in DynamicFieldOutput

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -192,12 +192,12 @@ impl DynamicFieldOutput {
     /// Deserialize the name of the dynamic field into the specified type.
     pub fn deserialize_name<T: DeserializeOwned>(
         &self,
-        expected_type: TypeTag,
+        expected_type: &TypeTag,
     ) -> Result<T, anyhow::Error> {
         assert_eq!(
-            expected_type, self.name.type_,
+            expected_type, &self.name.type_,
             "Expected type {}, but got {}",
-            expected_type, self.name.type_
+            expected_type, &self.name.type_
         );
 
         let bcs = &self.name.bcs;
@@ -207,12 +207,12 @@ impl DynamicFieldOutput {
     /// Deserialize the value of the dynamic field into the specified type.
     pub fn deserialize_value<T: DeserializeOwned>(
         &self,
-        expected_type: TypeTag,
+        expected_type: &TypeTag,
     ) -> Result<T, anyhow::Error> {
         let typetag = self.value.as_ref().map(|(typename, _)| typename);
         assert_eq!(
             Some(&expected_type),
-            typetag,
+            typetag.as_ref(),
             "Expected type {}, but got {:?}",
             expected_type,
             typetag
@@ -1210,8 +1210,6 @@ impl Client {
 // This function is used in tests to create a new client instance for the local server.
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use base64ct::Encoding;
     use futures::StreamExt;
     use sui_types::types::Ed25519PublicKey;

--- a/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
+++ b/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
@@ -135,16 +135,16 @@ impl DynamicFieldValue {
     }
 
     /// Return the typename and bcs of this dynamic field value.
-    pub fn type_bcs(&self) -> Option<(String, Vec<u8>)> {
+    pub fn type_bcs(&self) -> Option<(TypeTag, Vec<u8>)> {
         match self {
             DynamicFieldValue::MoveObject(mo) => mo.contents.as_ref().map(|o| {
                 (
-                    o.type_.repr.clone(),
+                    TypeTag::from_str(&o.type_.repr.clone()).expect("Invalid TypeTag"),
                     base64ct::Base64::decode_vec(&o.bcs.0).expect("Invalid Base64"),
                 )
             }),
             DynamicFieldValue::MoveValue(mv) => Some((
-                mv.type_.repr.clone(),
+                TypeTag::from_str(&mv.type_.repr.clone()).expect("Invalid TypeTag"),
                 base64ct::Base64::decode_vec(&mv.bcs.0).expect("Invalid Base64"),
             )),
             _ => None,

--- a/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
+++ b/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
@@ -137,13 +137,16 @@ impl DynamicFieldValue {
     /// Return the typename and bcs of this dynamic field value.
     pub fn type_bcs(&self) -> Option<(String, Vec<u8>)> {
         match self {
-            DynamicFieldValue::MoveObject(mo) => mo
-                .contents
-                .as_ref()
-                .map(|o| (o.type_.repr.clone(), o.bcs.0.clone().into())),
-            DynamicFieldValue::MoveValue(mv) => {
-                Some((mv.type_.repr.clone(), mv.bcs.0.clone().into()))
-            }
+            DynamicFieldValue::MoveObject(mo) => mo.contents.as_ref().map(|o| {
+                (
+                    o.type_.repr.clone(),
+                    base64ct::Base64::decode_vec(&o.bcs.0).expect("Invalid Base64"),
+                )
+            }),
+            DynamicFieldValue::MoveValue(mv) => Some((
+                mv.type_.repr.clone(),
+                base64ct::Base64::decode_vec(&mv.bcs.0).expect("Invalid Base64"),
+            )),
             _ => None,
         }
     }


### PR DESCRIPTION
Forgot to decode bcs from base64 for dynamic fields. This also changes to using `Typetag` for the return type in DynamicFieldOutput, to ensure consistency all around.