### PR TITLE
[GraphQL Client] Add total transaction blocks query

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -621,7 +621,7 @@ impl Client {
     /// provided, it will use the last known checkpoint id.
     pub async fn checkpoint(
         &self,
-        digest: Option<String>,
+        digest: Option<Digest>,
         seq_num: Option<u64>,
     ) -> Result<Option<CheckpointSummary>, Error> {
         ensure!(
@@ -631,7 +631,7 @@ impl Client {
 
         let operation = CheckpointQuery::build(CheckpointArgs {
             id: CheckpointId {
-                digest,
+                digest: digest.map(|d| d.to_string()),
                 sequence_number: seq_num,
             },
         });

--- a/crates/sui-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/sui-graphql-client/src/query_types/checkpoint.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use std::str::FromStr;
 
 use anyhow::Error;
 use chrono::DateTime as ChronoDT;

--- a/crates/sui-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/sui-graphql-client/src/query_types/checkpoint.rs
@@ -119,10 +119,10 @@ impl TryInto<CheckpointSummary> for Checkpoint {
             .map_err(|e| Error::msg(format!("Cannot parse DateTime: {e}")))?
             .timestamp_millis()
             .try_into()?;
-        let content_digest = CheckpointContentsDigest::from_str(&self.digest)?;
+        let content_digest = CheckpointContentsDigest::from_base58(&self.digest)?;
         let previous_digest = self
             .previous_checkpoint_digest
-            .map(|d| CheckpointDigest::from_str(&d))
+            .map(|d| CheckpointDigest::from_base58(&d))
             .transpose()?;
         let epoch_rolling_gas_cost_summary = self
             .rolling_gas_summary

--- a/crates/sui-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/sui-graphql-client/src/query_types/checkpoint.rs
@@ -28,6 +28,19 @@ pub struct CheckpointQuery {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "Query", variables = "CheckpointArgs")]
+pub struct CheckpointTotalTxQuery {
+    #[arguments(id: $id)]
+    pub checkpoint: Option<CheckpointTotalTx>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "Checkpoint")]
+pub struct CheckpointTotalTx {
+    pub network_total_transactions: Option<u64>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "Query", variables = "CheckpointsArgs")]
 pub struct CheckpointsQuery {
     pub checkpoints: CheckpointConnection,

--- a/crates/sui-graphql-client/src/query_types/mod.rs
+++ b/crates/sui-graphql-client/src/query_types/mod.rs
@@ -30,6 +30,7 @@ pub use chain::ChainIdentifierQuery;
 pub use checkpoint::CheckpointArgs;
 pub use checkpoint::CheckpointId;
 pub use checkpoint::CheckpointQuery;
+pub use checkpoint::CheckpointTotalTxQuery;
 pub use checkpoint::CheckpointsArgs;
 pub use checkpoint::CheckpointsQuery;
 pub use coin::CoinMetadata;


### PR DESCRIPTION
This PR adds total transaction blocks queries that return the number of tx blocks up to the specified checkpoint. 
In addition, it fixes two issues on checkpoint digests
- moves the digest to be a Digest type
- checkpoint digests were not base58 decoded