### PR TITLE
[GraphQL Client] Fetch dynamic field via owner instead of object.

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -764,7 +764,7 @@ impl Client {
 
         let result = response
             .data
-            .and_then(|d| d.object)
+            .and_then(|d| d.owner)
             .and_then(|o| o.dynamic_field)
             .map(|df| df.try_into())
             .transpose()

--- a/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
+++ b/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
@@ -40,16 +40,12 @@ pub struct ObjectOwner {
 #[cynic(schema = "rpc", graphql_type = "Query", variables = "DynamicFieldArgs")]
 pub struct DynamicFieldQuery {
     #[arguments(address: $address)]
-    pub object: Option<ObjectField>,
+    pub owner: Option<OwnerField>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema = "rpc",
-    graphql_type = "Object",
-    variables = "DynamicFieldArgs"
-)]
-pub struct ObjectField {
+#[cynic(schema = "rpc", graphql_type = "Owner", variables = "DynamicFieldArgs")]
+pub struct OwnerField {
     #[arguments(name: $name)]
     pub dynamic_field: Option<DynamicField>,
 }


### PR DESCRIPTION
This PR fixes a bug with the way dynamic fields are fetched. If we use the owner instead of objects, we also get the DFs on wrapped objects IIUC.