### PR TITLE
[GraphQL Client] Use `bcs` from `Checkpoint` instead of manual conversion.

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -2133,18 +2133,28 @@ mod tests {
             chckp.unwrap_err()
         );
         let chckp_id = chckp.unwrap().unwrap();
-        let total_transaction_blocks = client.total_transaction_blocks_by_seq_num(chckp_id).await;
-        assert!(total_transaction_blocks.is_ok());
-        assert!(total_transaction_blocks.unwrap().is_some_and(|tx| tx > 0));
-
-        let chckp = client.checkpoint(None, Some(chckp_id)).await;
-        assert!(chckp.is_ok());
-        let digest = chckp.unwrap().unwrap().content_digest;
         let total_transaction_blocks = client
+            .total_transaction_blocks_by_seq_num(chckp_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(total_transaction_blocks > 0);
+
+        let chckp = client
+            .checkpoint(None, Some(chckp_id))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let digest = chckp.digest();
+        let total_transaction_blocks_by_digest = client
             .total_transaction_blocks_by_digest(digest.into())
             .await;
-        assert!(total_transaction_blocks.is_ok());
-        assert!(total_transaction_blocks.unwrap().is_some_and(|tx| tx > 0));
+        assert!(total_transaction_blocks_by_digest.is_ok());
+        assert_eq!(
+            total_transaction_blocks_by_digest.unwrap().unwrap(),
+            total_transaction_blocks
+        );
     }
 
     #[tokio::test]

--- a/crates/sui-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/sui-graphql-client/src/query_types/checkpoint.rs
@@ -78,7 +78,7 @@ pub struct CheckpointId {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "Checkpoint")]
 pub struct Checkpoint {
-    pub checkpoint_summary_bcs: Option<Base64>,
+    pub bcs: Option<Base64>,
 }
 
 impl TryInto<CheckpointSummary> for Checkpoint {
@@ -86,7 +86,7 @@ impl TryInto<CheckpointSummary> for Checkpoint {
 
     fn try_into(self) -> Result<CheckpointSummary, Error> {
         let checkpoint = self
-            .checkpoint_summary_bcs
+            .bcs
             .map(|x| base64ct::Base64::decode_vec(&x.0))
             .transpose()?
             .map(|bcs| {

--- a/crates/sui-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/sui-graphql-client/src/query_types/checkpoint.rs
@@ -2,20 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use base64ct::Encoding;
-use chrono::DateTime as ChronoDT;
-use sui_types::types::CheckpointContentsDigest;
-use sui_types::types::CheckpointDigest;
 use sui_types::types::CheckpointSummary;
-use sui_types::types::GasCostSummary as NativeGasCostSummary;
 
 use crate::error;
 use crate::error::Error;
 use crate::error::Kind;
 use crate::query_types::schema;
 use crate::query_types::Base64;
-use crate::query_types::BigInt;
-use crate::query_types::DateTime;
-use crate::query_types::Epoch;
 use crate::query_types::PageInfo;
 
 // ===========================================================================


### PR DESCRIPTION
Get checkpoint summary from bcs instead of manually converting it. This is dependent on first landing
https://github.com/MystenLabs/sui/pull/20340

- [x] Update the schema with the `bcs` comment.
- [x] Update the Sui CLI to enable the new schema support.

Note: this will have to sit for a while because we have no releases in the upcoming weeks so we cannot get an updated version of the CLI that includes the latest schema changes.