### PR TITLE
Fix issue with serde renaming

### DIFF
--- a/crates/sui-sdk-types/src/types/transaction/unresolved.rs
+++ b/crates/sui-sdk-types/src/types/transaction/unresolved.rs
@@ -118,7 +118,7 @@ pub enum InputKind {
 #[cfg_attr(
     feature = "serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize),
-    serde(rename = "UnresolvedInput"),
+    serde(rename = "UnresolvedInput")
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Input {


### PR DESCRIPTION
This `,` breaks the cargo fmt.