### PR TITLE
Return a tuple of Event, TxDigest

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -940,23 +940,27 @@ impl Client {
         if let Some(events) = response.data {
             let ec = events.events;
             let page_info = ec.page_info;
-            
-            let events_with_digests = ec.nodes.into_iter()
+
+            let events_with_digests = ec
+                .nodes
+                .into_iter()
                 .map(|node| -> Result<(Event, TransactionDigest)> {
-                    let event = bcs::from_bytes::<Event>(
-                        &base64ct::Base64::decode_vec(&node.bcs.0)?
-                    )?;
-                    
-                    let tx_digest = node.transaction_block
+                    let event =
+                        bcs::from_bytes::<Event>(&base64ct::Base64::decode_vec(&node.bcs.0)?)?;
+
+                    let tx_digest = node
+                        .transaction_block
                         .ok_or_else(Error::empty_response_error)?
                         .digest
-                        .ok_or_else(|| Error::from_error(
-                            Kind::Deserialization,
-                            "Expected a transaction digest for this event, but it is missing.",
-                        ))?;
-                    
+                        .ok_or_else(|| {
+                            Error::from_error(
+                                Kind::Deserialization,
+                                "Expected a transaction digest for this event, but it is missing.",
+                            )
+                        })?;
+
                     let tx_digest = TransactionDigest::from_base58(&tx_digest)?;
-                    
+
                     Ok((event, tx_digest))
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/crates/sui-graphql-client/src/query_types/events.rs
+++ b/crates/sui-graphql-client/src/query_types/events.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::query_types::schema;
+use crate::query_types::transaction::TransactionBlockDigest;
 use crate::query_types::Address;
 use crate::query_types::Base64;
 use crate::query_types::PageInfo;
@@ -54,4 +55,5 @@ pub struct EventFilter {
 #[cynic(schema = "rpc", graphql_type = "Event")]
 pub struct Event {
     pub bcs: Base64,
+    pub transaction_block: Option<TransactionBlockDigest>,
 }

--- a/crates/sui-graphql-client/src/query_types/transaction.rs
+++ b/crates/sui-graphql-client/src/query_types/transaction.rs
@@ -93,6 +93,12 @@ pub struct TransactionBlock {
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "TransactionBlock")]
+pub struct TransactionBlockDigest {
+    pub digest: Option<String>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "TransactionBlock")]
 pub struct TxBlockEffects {
     pub effects: Option<TransactionBlockEffects>,
 }


### PR DESCRIPTION
This PR changes the return type for the `events` API to include the `TransactionDigest` corresponding to the transaction block that issued this event. 

@dario requested this change.