### PR TITLE
[GraphQL Client] Update schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Get the Sui testnet binary and start a local network
         shell: bash
         env:
-          SUI_BINARY_VERSION: "1.36.1" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
+          SUI_BINARY_VERSION: "1.39.1" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
           SUI_NETWORK_RELEASE: "testnet" # which release to use
         run: |
           ASSET_NAME="sui-$SUI_NETWORK_RELEASE-v$SUI_BINARY_VERSION-ubuntu-x86_64.tgz"

--- a/crates/sui-graphql-client-build/schema.graphql
+++ b/crates/sui-graphql-client-build/schema.graphql
@@ -175,6 +175,11 @@ enum AddressTransactionBlockRelationship {
 }
 
 """
+An Authenticator represents the access control rules for a ConsensusV2 object.
+"""
+union Authenticator = Address
+
+"""
 System transaction for creating the on-chain state used by zkLogin.
 """
 type AuthenticatorStateCreateTransaction {
@@ -448,6 +453,10 @@ type Checkpoint {
 	By default, the scanning range consists of all transactions in this checkpoint.
 	"""
 	transactionBlocks(first: Int, after: String, last: Int, before: String, filter: TransactionBlockFilter, scanLimit: Int): TransactionBlockConnection!
+	"""
+	The Base64 serialized BCS bytes of CheckpointSummary for this checkpoint.
+	"""
+	bcs: Base64
 }
 
 type CheckpointConnection {
@@ -846,6 +855,16 @@ type ConsensusCommitPrologueTransaction {
 	transaction).
 	"""
 	consensusCommitDigest: String
+}
+
+"""
+A ConsensusV2 object is an object that is automatically versioned by the consensus protocol
+and allows different authentication modes based on the chosen authenticator.
+(Initially, only single-owner authentication is supported.)
+"""
+type ConsensusV2 {
+	startVersion: UInt53!
+	authenticator: Authenticator
 }
 
 """
@@ -2905,7 +2924,7 @@ enum ObjectKind {
 """
 The object's owner type: Immutable, Shared, Parent, or Address.
 """
-union ObjectOwner = Immutable | Shared | Parent | AddressOwner
+union ObjectOwner = Immutable | Shared | Parent | AddressOwner | ConsensusV2
 
 input ObjectRef {
 	"""
@@ -3382,7 +3401,8 @@ type Query {
 	"""
 	typeByName(name: String!): MoveType!
 	"""
-	The coin metadata associated with the given coin type.
+	The coin metadata associated with the given coin type. Note that if the latest version of
+	the coin's metadata is wrapped or deleted, it will not be found.
 	"""
 	coinMetadata(coinType: String!): CoinMetadata
 	"""


### PR DESCRIPTION
This PR updates:
- the GraphQL schema to the one in the branch `releases/sui-v1.39.0`
- the CI to use Sui CLI v1.39.1 to match the schema.