### PR TITLE
[GraphQL Client] Force reqwest to use rustls-tls to avoid using openssl

### DIFF
--- a/crates/sui-graphql-client/Cargo.toml
+++ b/crates/sui-graphql-client/Cargo.toml
@@ -17,7 +17,7 @@ bcs = "0.1.4"
 chrono = "0.4.26"
 cynic = "3.7.3"
 futures = "0.3.29"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0.144" }
 serde_json = {version = "1.0.95"}
 sui-types = { package = "sui-sdk-types", path = "../sui-sdk-types", features = ["serde"] }


### PR DESCRIPTION
Force reqwest to use rustls-tls to avoid using openssl via native-tls crate.