### PR TITLE
chore: update proptest to 1.6.0

### DIFF
--- a/crates/sui-crypto/Cargo.toml
+++ b/crates/sui-crypto/Cargo.toml
@@ -94,7 +94,7 @@ hex = "0.4.3"
 serde_json = { version = "1.0.128" }
 
 # proptest support in tests
-proptest = { version = "1.6.0", default-features = false, features = ["std"], optional = true }
+proptest = { version = "1.6.0", default-features = false, features = ["std"] }
 test-strategy = "0.4.0"
 
 [target.wasm32-unknown-unknown.dev-dependencies]

--- a/crates/sui-crypto/Cargo.toml
+++ b/crates/sui-crypto/Cargo.toml
@@ -94,10 +94,7 @@ hex = "0.4.3"
 serde_json = { version = "1.0.128" }
 
 # proptest support in tests
-#
-# Pin to this specific commit in order to work around an issue where proptest doesn't build properly in wasm environments
-# see https://github.com/proptest-rs/proptest/pull/270 for more info
-proptest = { git = "https://github.com/bmwill/proptest.git", rev = "bc36db126183bce18c8bc595f0c0cfeac48b870c", default-features = false, features = ["std"] }
+proptest = { version = "1.6.0", default-features = false, features = ["std"], optional = true }
 test-strategy = "0.4.0"
 
 [target.wasm32-unknown-unknown.dev-dependencies]

--- a/crates/sui-sdk-types/Cargo.toml
+++ b/crates/sui-sdk-types/Cargo.toml
@@ -54,7 +54,7 @@ rand_core = { version = "0.6.4", optional = true }
 blake2 = { version = "0.10.6", optional = true }
 
 # proptest support
-proptest = { version = "1.5.0", default-features = false, features = ["std"], optional = true }
+proptest = { version = "1.6.0", default-features = false, features = ["std"], optional = true }
 test-strategy = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/crates/sui-sdk-types/Makefile
+++ b/crates/sui-sdk-types/Makefile
@@ -17,7 +17,7 @@ test:
 
 .PHONY: wasm
 wasm:
-	CC=clang wasm-pack test --node
+	CC=clang wasm-pack test --node --all-features
 
 %:
 	$(MAKE) -C ../.. $@

--- a/crates/sui-sdk-types/Makefile
+++ b/crates/sui-sdk-types/Makefile
@@ -12,20 +12,12 @@ clippy:
 
 .PHONY: test
 test:
-	# Note on proptest:
-	#
-	# Pin to this specific commit in order to work around an issue where proptest doesn't build properly in wasm environments
-	# see https://github.com/proptest-rs/proptest/pull/270 for more info
-	cargo nextest run --all-features --config 'patch.crates-io.proptest.git="https://github.com/bmwill/proptest.git"' --config 'patch.crates-io.proptest.rev="0a140789d25f4999632b8b88aedb1e2ba056151d"'
+	cargo nextest run --all-features
 	cargo test --doc
 
 .PHONY: wasm
 wasm:
-	# Note on proptest:
-	#
-	# Pin to this specific commit in order to work around an issue where proptest doesn't build properly in wasm environments
-	# see https://github.com/proptest-rs/proptest/pull/270 for more info
-	CC=clang wasm-pack test --node --all-features --config 'patch.crates-io.proptest.git="https://github.com/bmwill/proptest.git"' --config 'patch.crates-io.proptest.rev="0a140789d25f4999632b8b88aedb1e2ba056151d"'
+	CC=clang wasm-pack test --node
 
 %:
 	$(MAKE) -C ../.. $@


### PR DESCRIPTION
Update proptest to 1.6.0 which addresses the various bugs that were causing us to pin to a patched version.