### PR TITLE
chore: add `help` target to Makefile to display the usage of all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,64 @@
 # Set the default target of this Makefile
 .PHONY: all
-all:: ci
+all:: ci ## Default target, runs the CI process
 
 .PHONY: check-features
-check-features:
+check-features: ## Check feature flags for crates
 	$(MAKE) -C crates/sui-sdk-types check-features
 	$(MAKE) -C crates/sui-crypto check-features
 
 .PHONY: check-fmt
-check-fmt:
+check-fmt: ## Check code formatting
 	cargo fmt -- --config imports_granularity=Item --check
 
 .PHONY: fmt
-fmt:
+fmt: ## Format code
 	cargo fmt -- --config imports_granularity=Item
 
 .PHONY: clippy
-clippy:
+clippy: ## Run Clippy linter
 	cargo clippy --all-features --all-targets
 
 .PHONY: test
-test:
+test: ## Run unit tests
 	cargo nextest run --all-features -p sui-sdk-types -p sui-crypto
 	cargo test --doc
 
-package_%.json: crates/sui-transaction-builder/tests/%/Move.toml crates/sui-transaction-builder/tests/%/sources/*.move
+package_%.json: crates/sui-transaction-builder/tests/%/Move.toml crates/sui-transaction-builder/tests/%/sources/*.move ## Generate JSON files for tests
 	cd crates/sui-transaction-builder/tests/$(*F) && sui move build --ignore-chain --dump-bytecode-as-base64 > ../../$@
 
 .PHONY: test-with-localnet
-test-with-localnet: package_test_example_v1.json package_test_example_v2.json
+test-with-localnet: package_test_example_v1.json package_test_example_v2.json ## Run tests with localnet
 	cargo nextest run -p sui-graphql-client -p sui-transaction-builder
 
 .PHONY: wasm
-wasm:
+wasm: ## Build WASM modules
 	$(MAKE) -C crates/sui-sdk-types wasm
 	$(MAKE) -C crates/sui-crypto wasm
 
 .PHONY: doc
-doc:
+doc: ## Generate documentation
 	RUSTDOCFLAGS="--cfg=doc_cfg -Zunstable-options --generate-link-to-definition" RUSTC_BOOTSTRAP=1 cargo doc --all-features --no-deps
 
 .PHONY: doc-open
-doc-open:
+doc-open: ## Generate and open documentation
 	RUSTDOCFLAGS="--cfg=doc_cfg -Zunstable-options --generate-link-to-definition" RUSTC_BOOTSTRAP=1 cargo doc --all-features --no-deps --open
 
 .PHONY: ci
-ci: check-features check-fmt test wasm
+ci: check-features check-fmt test wasm ## Run the full CI process
 
 .PHONY: ci-full
-ci-full: ci doc
+ci-full: ci doc ## Run the full CI process and generate documentation
 
 .PHONY: clean
-clean:
+clean: ## Clean build artifacts
 	cargo clean
 
 .PHONY: clean-all
-clean-all: clean
-	git clean -dX
+clean-all: clean ## Clean all generated files, including those ignored by Git. Force removal.
+	git clean -dXf
+
+.PHONY: help
+help: ## Show this help
+	@echo "Available targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
`make help` outputs

![img_v3_02i3_37dbd29e-3d7d-4758-8970-14a0aeb41e1g](https://github.com/user-attachments/assets/60fbb7b0-1294-48b8-9627-a42ab2046a34)
