### PR TITLE
feat(sui-sdk-types)!: `Object` content getters

### DIFF
--- a/crates/sui-sdk-types/src/object.rs
+++ b/crates/sui-sdk-types/src/object.rs
@@ -300,6 +300,13 @@ impl Object {
         }
     }
 
+    pub fn as_struct(&self) -> Option<&MoveStruct> {
+        match &self.data {
+            ObjectData::Struct(struct_) => Some(struct_),
+            _ => None,
+        }
+    }
+
     pub fn owner(&self) -> &Owner {
         &self.owner
     }

--- a/crates/sui-sdk-types/src/object.rs
+++ b/crates/sui-sdk-types/src/object.rs
@@ -223,6 +223,7 @@ impl MoveStruct {
         &self.type_
     }
 
+    #[doc(hidden)]
     pub fn has_public_transfer(&self) -> bool {
         self.has_public_transfer
     }


### PR DESCRIPTION
- 41a0604 **feat(sui-sdk-types): Object::as_struct getter**

- 9cc7fdd **feat(sui-sdk-types)!: remove `Object::has_public_transfer` getter**
  Probably a good idea to keep `MoveStruct::has_public_transfer` private
  to avoid any misinterpretation there (there's a comment clearly
  stating it's deprecated)

Done as separate commits to make it easy to revert any change.

Closes #72
