### PR TITLE
fix: use `owner` instead of `object` in gql `DynamicObjectFieldQuery`

### DIFF
--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -812,7 +812,7 @@ impl Client {
 
         let result: Option<DynamicFieldOutput> = response
             .data
-            .and_then(|d| d.object)
+            .and_then(|d| d.owner)
             .and_then(|o| o.dynamic_object_field)
             .map(|df| df.try_into())
             .transpose()?;

--- a/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
+++ b/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
@@ -103,11 +103,7 @@ pub struct DynamicFieldName {
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(
-    schema = "rpc",
-    graphql_type = "Owner",
-    variables = "DynamicFieldArgs"
-)]
+#[cynic(schema = "rpc", graphql_type = "Owner", variables = "DynamicFieldArgs")]
 pub struct DynamicObjectField {
     #[arguments(name: $name)]
     pub dynamic_object_field: Option<DynamicField>,

--- a/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
+++ b/crates/sui-graphql-client/src/query_types/dynamic_fields.rs
@@ -105,7 +105,7 @@ pub struct DynamicFieldName {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema = "rpc",
-    graphql_type = "Object",
+    graphql_type = "Owner",
     variables = "DynamicFieldArgs"
 )]
 pub struct DynamicObjectField {
@@ -116,7 +116,7 @@ pub struct DynamicObjectField {
 #[cynic(schema = "rpc", graphql_type = "Query", variables = "DynamicFieldArgs")]
 pub struct DynamicObjectFieldQuery {
     #[arguments(address: $address)]
-    pub object: Option<DynamicObjectField>,
+    pub owner: Option<DynamicObjectField>,
 }
 
 impl DynamicFieldValue {


### PR DESCRIPTION
This PR fixes a bug with fetching dynamic _**object**_  fields by changing `object` field in `DynamicObjectFieldQuery` query to `owner`.

I believe that change was already applied for regular DFs, but not object ones, here: #54
