### PR TITLE
[GraphQL] Update GraphQL schema and make appropriate changes on ObjectFilter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Get the Sui testnet binary and start a local network
         shell: bash
         env:
-          SUI_BINARY_VERSION: "1.39.3" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
+          SUI_BINARY_VERSION: "1.44.2" # used for downloading a specific Sui binary versions that matches the GraphQL schema for local network tests
           SUI_NETWORK_RELEASE: "testnet" # which release to use
         run: |
           ASSET_NAME="sui-$SUI_NETWORK_RELEASE-v$SUI_BINARY_VERSION-ubuntu-x86_64.tgz"

--- a/crates/sui-crypto/src/zklogin/mod.rs
+++ b/crates/sui-crypto/src/zklogin/mod.rs
@@ -156,7 +156,7 @@ fn verify_extended_claim(
                 BASE64_URL_CHARSET
                     .find(c)
                     .map(|index| index as u8)
-                    .map(|index| (0..6).rev().map(move |i| index >> i & 1))
+                    .map(|index| (0..6).rev().map(move |i| (index >> i) & 1))
                     .ok_or_else(|| SignatureError::from_source("base64_to_bitarry invalid input"))
             })
             .flatten_ok()

--- a/crates/sui-graphql-client-build/schema.graphql
+++ b/crates/sui-graphql-client-build/schema.graphql
@@ -1046,7 +1046,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, before: String, last: Int, after: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | AuthenticatorStateExpireTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | BridgeStateCreateTransaction | BridgeCommitteeInitTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | AuthenticatorStateExpireTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | BridgeStateCreateTransaction | BridgeCommitteeInitTransaction | StoreExecutionTimeObservationsTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""
@@ -2879,7 +2879,7 @@ objects are ones whose
 
 - Type matches the `type` filter,
 - AND, whose owner matches the `owner` filter,
-- AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+- AND, whose ID is in `objectIds`.
 """
 input ObjectFilter {
 	"""
@@ -2898,10 +2898,6 @@ input ObjectFilter {
 	Filter for live objects by their IDs.
 	"""
 	objectIds: [SuiAddress!]
-	"""
-	Filter for live or potentially historical objects by their ID and version.
-	"""
-	objectKeys: [ObjectKey!]
 }
 
 input ObjectKey {
@@ -3325,6 +3321,10 @@ type Query {
 	"""
 	transactionBlock(digest: String!): TransactionBlock
 	"""
+	Fetch a list of objects by their IDs and versions.
+	"""
+	multiGetObjects(keys: [ObjectKey!]!): [Object]!
+	"""
 	The coin objects that exist in the network.
 	
 	The type field is a string of the inner type of the coin by which to filter (e.g.
@@ -3598,6 +3598,10 @@ type ServiceConfig {
 	Maximum number of transaction ids that can be passed to a `TransactionBlockFilter`.
 	"""
 	maxTransactionIds: Int!
+	"""
+	Maximum number of keys that can be passed to a `multiGetObjects` query.
+	"""
+	maxMultiGetObjectsKeys: Int!
 	"""
 	Maximum number of candidates to scan when gathering a page of results.
 	"""
@@ -3968,6 +3972,13 @@ type StorageFund {
 	non-refundable balance.
 	"""
 	nonRefundableBalance: BigInt
+}
+
+type StoreExecutionTimeObservationsTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 

--- a/crates/sui-graphql-client/src/lib.rs
+++ b/crates/sui-graphql-client/src/lib.rs
@@ -583,7 +583,6 @@ impl Client {
                     type_: Some(coin_type.unwrap_or("0x2::coin::Coin")),
                     owner: Some(owner),
                     object_ids: None,
-                    object_keys: None,
                 }),
                 pagination_filter,
             )
@@ -1031,7 +1030,6 @@ impl Client {
     ///     type_: None,
     ///     owner: Some(Address::from_str("test").unwrap().into()),
     ///     object_ids: None,
-    ///     object_keys: None,
     /// };
     ///
     /// let owned_objects = client.objects(None, None, Some(filter), None, None).await;

--- a/crates/sui-graphql-client/src/query_types/object.rs
+++ b/crates/sui-graphql-client/src/query_types/object.rs
@@ -62,7 +62,6 @@ pub struct ObjectFilter<'a> {
     pub type_: Option<&'a str>,
     pub owner: Option<Address>,
     pub object_ids: Option<Vec<Address>>,
-    pub object_keys: Option<Vec<ObjectKey>>,
 }
 
 #[derive(Clone, cynic::InputObject, Debug)]


### PR DESCRIPTION
This PR updates the GraphQL schema to the one in v1.44.2, as the `objectKeys` of `ObjectFilter` type has been dropped in favor of a `multiGetObjects` top-level query.