### PR TITLE
Hotfix: add `ConsensusCommitPrologueV4` transaction kind

### DIFF
--- a/crates/sui-sdk-types/src/transaction/mod.rs
+++ b/crates/sui-sdk-types/src/transaction/mod.rs
@@ -123,8 +123,47 @@ pub enum TransactionKind {
     ConsensusCommitPrologueV2(ConsensusCommitPrologueV2),
 
     ConsensusCommitPrologueV3(ConsensusCommitPrologueV3),
+    ConsensusCommitPrologueV4(ConsensusCommitPrologueV4),
     // .. more transaction types go here
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+pub struct ConsensusCommitPrologueV4 {
+    /// Epoch of the commit prologue transaction
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    pub epoch: u64,
+    /// Consensus round of the commit
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    pub round: u64,
+    /// The sub DAG index of the consensus commit. This field will be populated if there
+    /// are multiple consensus commits per round.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::_serde::OptionReadableDisplay")
+    )]
+    pub sub_dag_index: Option<u64>,
+    /// Unix timestamp from consensus commit.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    pub commit_timestamp_ms: u64,
+    /// Digest of consensus output
+    pub consensus_commit_digest: ConsensusCommitDigest,
+    /// Stores consensus handler determined shared object version assignments.
+    pub consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+    /// Digest of any additional state computed by the consensus handler.
+    /// Used to detect forking bugs as early as possible.
+    pub additional_state_digest: AdditionalConsensusStateDigest,
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+pub struct AdditionalConsensusStateDigest(crate::Digest);
 
 /// EndOfEpochTransactionKind
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/sui-sdk-types/src/transaction/serialization.rs
+++ b/crates/sui-sdk-types/src/transaction/serialization.rs
@@ -122,6 +122,7 @@ mod transaction_kind {
     use crate::transaction::ConsensusCommitPrologue;
     use crate::transaction::ConsensusCommitPrologueV2;
     use crate::transaction::ConsensusCommitPrologueV3;
+    use crate::transaction::ConsensusCommitPrologueV4;
     use crate::transaction::EndOfEpochTransactionKind;
     use crate::transaction::GenesisTransaction;
     use crate::transaction::ProgrammableTransaction;
@@ -142,6 +143,7 @@ mod transaction_kind {
         RandomnessStateUpdate(&'a RandomnessStateUpdate),
         ConsensusCommitPrologueV2(&'a ConsensusCommitPrologueV2),
         ConsensusCommitPrologueV3(&'a ConsensusCommitPrologueV3),
+        ConsensusCommitPrologueV4(&'a ConsensusCommitPrologueV4),
     }
 
     #[derive(serde_derive::Deserialize)]
@@ -159,6 +161,7 @@ mod transaction_kind {
         RandomnessStateUpdate(RandomnessStateUpdate),
         ConsensusCommitPrologueV2(ConsensusCommitPrologueV2),
         ConsensusCommitPrologueV3(ConsensusCommitPrologueV3),
+        ConsensusCommitPrologueV4(ConsensusCommitPrologueV4),
     }
 
     #[derive(serde_derive::Serialize)]
@@ -172,6 +175,7 @@ mod transaction_kind {
         RandomnessStateUpdate(&'a RandomnessStateUpdate),
         ConsensusCommitPrologueV2(&'a ConsensusCommitPrologueV2),
         ConsensusCommitPrologueV3(&'a ConsensusCommitPrologueV3),
+        ConsensusCommitPrologueV4(&'a ConsensusCommitPrologueV4),
     }
     #[derive(serde_derive::Deserialize)]
     enum BinaryTransactionKind {
@@ -184,6 +188,7 @@ mod transaction_kind {
         RandomnessStateUpdate(RandomnessStateUpdate),
         ConsensusCommitPrologueV2(ConsensusCommitPrologueV2),
         ConsensusCommitPrologueV3(ConsensusCommitPrologueV3),
+        ConsensusCommitPrologueV4(ConsensusCommitPrologueV4),
     }
 
     impl Serialize for TransactionKind {
@@ -216,6 +221,9 @@ mod transaction_kind {
                     Self::ConsensusCommitPrologueV3(k) => {
                         ReadableTransactionKindRef::ConsensusCommitPrologueV3(k)
                     }
+                    Self::ConsensusCommitPrologueV4(k) => {
+                        ReadableTransactionKindRef::ConsensusCommitPrologueV4(k)
+                    }
                 };
                 readable.serialize(serializer)
             } else {
@@ -240,6 +248,9 @@ mod transaction_kind {
                     }
                     Self::ConsensusCommitPrologueV3(k) => {
                         BinaryTransactionKindRef::ConsensusCommitPrologueV3(k)
+                    }
+                    Self::ConsensusCommitPrologueV4(k) => {
+                        BinaryTransactionKindRef::ConsensusCommitPrologueV4(k)
                     }
                 };
                 binary.serialize(serializer)
@@ -275,6 +286,9 @@ mod transaction_kind {
                     ReadableTransactionKind::ConsensusCommitPrologueV3(k) => {
                         Self::ConsensusCommitPrologueV3(k)
                     }
+                    ReadableTransactionKind::ConsensusCommitPrologueV4(k) => {
+                        Self::ConsensusCommitPrologueV4(k)
+                    }
                 })
             } else {
                 BinaryTransactionKind::deserialize(deserializer).map(|binary| match binary {
@@ -298,6 +312,9 @@ mod transaction_kind {
                     }
                     BinaryTransactionKind::ConsensusCommitPrologueV3(k) => {
                         Self::ConsensusCommitPrologueV3(k)
+                    }
+                    BinaryTransactionKind::ConsensusCommitPrologueV4(k) => {
+                        Self::ConsensusCommitPrologueV4(k)
                     }
                 })
             }


### PR DESCRIPTION
This `TransactionKind` variant started being produced on testnet epoch 679. However, `sui-sdk-types@0.0.2` doesn't yet have this variant.

Since we were deserializing checkpoints produced by our testnet fullnode into this library's `CheckpointData` type, this led to a `serde` error, which subsequently took down our ingestion pipelines on testnet.

For reference, the error was as follows:
```
Reading checkpoint file /sui/checkpoints/175059402.chk: invalid value: integer '9', expect edvariant index 0 <= i < 9
```
