### PR TITLE
Add single byte constructor to ObjectId

### DIFF
--- a/crates/sui-sdk-types/src/address.rs
+++ b/crates/sui-sdk-types/src/address.rs
@@ -70,7 +70,7 @@ impl Address {
         Self(bytes)
     }
 
-    const fn from_u8(byte: u8) -> Self {
+    pub const fn from_u8(byte: u8) -> Self {
         let mut address = Self::ZERO;
         address.0[31] = byte;
         address

--- a/crates/sui-sdk-types/src/object_id.rs
+++ b/crates/sui-sdk-types/src/object_id.rs
@@ -34,6 +34,11 @@ impl ObjectId {
         Self(Address::new(bytes))
     }
 
+    /// Generates a new ObjectId from single byte.
+    pub const fn from_u8(byte: u8) -> Self {
+        Self(Address::from_u8(byte))
+    }
+
     /// Returns the underlying byte array of an ObjectId.
     pub const fn into_inner(self) -> [u8; Self::LENGTH] {
         self.0.into_inner()


### PR DESCRIPTION
Thanks @bmwill for your guidance in draft pr: https://github.com/MystenLabs/sui-rust-sdk/pull/104, I managed to compile our implementation using `sui-sdk-types` and `sui-transaction-builder` 🙏

Will test to see if any functionality breaks later

Can we add 2 simple constructors to build `Address` or `ObjectId` from single byte? this is equivalent to `ObjectID::from_single_byte` in `sui-types`.
