### PR TITLE
owner: add support for ConsensusAddress Owner variant

### DIFF
--- a/crates/sui-sdk-types/src/object.rs
+++ b/crates/sui-sdk-types/src/object.rs
@@ -107,6 +107,18 @@ pub enum Owner {
     ),
     /// Object is immutable, and hence ownership doesn't matter.
     Immutable,
+
+    /// Object is exclusively owned by a single address and sequenced via consensus.
+    ConsensusAddress {
+        /// The version at which the object most recently became a consensus object.
+        /// This serves the same function as `initial_shared_version`, except it may change
+        /// if the object's Owner type changes.
+        #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+        start_version: Version,
+
+        /// The owner of the object.
+        owner: Address,
+    },
 }
 
 /// Object data, either a package or struct

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -905,6 +905,9 @@ mod tests {
                             panic!("Upgrade capability controlled by object")
                         }
                         sui_types::Owner::Immutable => panic!("Upgrade capability is stored immutably and cannot be used for upgrades"),
+                        sui_types::Owner::ConsensusAddress { .. } => {
+                            upgrade_cap = Some(tx.input(&obj))
+                        }
                     };
                     break;
                 }

--- a/crates/sui-transaction-builder/src/unresolved.rs
+++ b/crates/sui-transaction-builder/src/unresolved.rs
@@ -309,6 +309,9 @@ impl From<&sui_types::Object> for Input {
             Owner::Object(_) => input,
             Owner::Shared(at_version) => input.with_initial_shared_version(*at_version),
             Owner::Immutable => input.with_immutable_kind(),
+            Owner::ConsensusAddress { start_version, .. } => {
+                input.with_initial_shared_version(*start_version)
+            }
         }
     }
 }


### PR DESCRIPTION
This adds support for the new ConsensusAddress Owner variant which indicates that a single address has exclusive ownership of an object, but that the object is used as a "shared" input to transactions and version managmenet is handled by consensus similar to how this is done for shared objects.