### PR TITLE
sui-graphql-client: return address for CoinMetadata query

### DIFF
--- a/crates/sui-graphql-client/queries/coin_metadata.graphql
+++ b/crates/sui-graphql-client/queries/coin_metadata.graphql
@@ -1,5 +1,6 @@
 query CoinMetadataQuery($coinType: String!) {
   coinMetadata(coinType: $coinType) {
+    address
     decimals
     description
     iconUrl

--- a/crates/sui-graphql-client/src/query_types/coin.rs
+++ b/crates/sui-graphql-client/src/query_types/coin.rs
@@ -26,12 +26,15 @@ pub struct CoinMetadataArgs<'a> {
 // ===========================================================================
 
 use crate::query_types::schema;
+use crate::query_types::Address;
 use crate::query_types::BigInt;
 
 /// The coin metadata associated with the given coin type.
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "CoinMetadata")]
 pub struct CoinMetadata {
+    /// The CoinMetadata object ID.
+    pub address: Address,
     /// The number of decimal places used to represent the token.
     pub decimals: Option<i32>,
     /// Optional description of the token, provided by the creator of the token.


### PR DESCRIPTION
Added `address` to `CoinMetadata` type returned in `CoinMetadataQuery` used in Client.coin_metadata. Returning the id of the CoinMetadata object is essential from my perspective.