### PR TITLE
fix(graphql): prevent value fields from shadowing response input

### DIFF
--- a/crates/sui-graphql-macros/src/lib.rs
+++ b/crates/sui-graphql-macros/src/lib.rs
@@ -341,8 +341,7 @@ fn generate_struct_impl(
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     // Generate extraction code for each field
-    let mut field_extractions = Vec::new();
-    let mut field_names = Vec::new();
+    let mut field_initializers = vec![];
 
     for field in fields {
         let field_ident = field
@@ -374,9 +373,10 @@ fn generate_struct_impl(
 
         // Generate extraction code using the same parsed path
         let type_structure = validation::analyze_type(&field.ty);
-        let extraction = generate_field_extraction(&parsed_path, &type_structure, field_ident);
-        field_extractions.push(extraction);
-        field_names.push(field_ident);
+        let extraction = generate_field_extraction(&parsed_path, &type_structure);
+        field_initializers.push(quote! {
+            #field_ident: #extraction
+        });
     }
 
     // Generate both `from_value` and `Deserialize` impl:
@@ -387,10 +387,8 @@ fn generate_struct_impl(
     Ok(quote! {
         impl #impl_generics #ident #ty_generics #where_clause {
             pub fn from_value(value: serde_json::Value) -> Result<Self, String> {
-                #(#field_extractions)*
-
                 Ok(Self {
-                    #(#field_names),*
+                    #(#field_initializers),*
                 })
             }
         }
@@ -524,17 +522,14 @@ fn generate_enum_impl(
 fn generate_field_extraction(
     path: &path::ParsedPath,
     type_structure: &validation::TypeStructure,
-    field_ident: &syn::Ident,
 ) -> TokenStream2 {
     let full_path = &path.raw;
     let inner = generate_from_segments(full_path, &path.segments, type_structure);
     // The inner expression returns Result<T, String>, so we use ? to unwrap
-    quote! {
-        let #field_ident = {
-            let current = &value;
-            #inner?
-        };
-    }
+    quote! {{
+        let current = &value;
+        #inner?
+    }}
 }
 
 /// Recursively generate extraction code by traversing path segments.

--- a/crates/sui-graphql-macros/tests/extraction_test.rs
+++ b/crates/sui-graphql-macros/tests/extraction_test.rs
@@ -58,6 +58,28 @@ fn test_multiple_fields() {
     assert_eq!(data.digest, "abc123");
 }
 
+#[test]
+fn test_field_named_value_does_not_shadow_response_value() {
+    #[derive(Response)]
+    #[response(schema = "tests/test_schema.graphql")]
+    struct Data {
+        #[field(path = "chainIdentifier")]
+        value: String,
+        #[field(path = "checkpoint.digest")]
+        digest: String,
+    }
+
+    let json = serde_json::json!({
+        "chainIdentifier": "4c78adac",
+        "checkpoint": {
+            "digest": "abc123"
+        }
+    });
+    let data = Data::from_value(json).unwrap();
+    assert_eq!(data.value, "4c78adac");
+    assert_eq!(data.digest, "abc123");
+}
+
 // === Nullable Array Extraction ===
 // `?` markers control which segments tolerate null. `?[]` makes the array nullable.
 


### PR DESCRIPTION
## Description

The `Response` derive generated one local binding per response field. When a field named `value` came before another field, its binding shadowed the `value` parameter containing the original JSON response, so later fields tried to traverse the extracted field instead of the response root, which often led to compilation (type) errors.

Before:

```rust
pub fn from_value(value: serde_json::Value) -> Result<Self, String> {
    let value = {
        let current = &value;
        // extract value
    };
    let digest = {
        let current = &value;
        // incorrectly extracts from the value field
    };
    Ok(Self { value, digest })
}
```

After:

```rust
pub fn from_value(value: serde_json::Value) -> Result<Self, String> {
    Ok(Self {
        value: {
            let current = &value;
            // extract value
        },
        digest: {
            let current = &value;
            // extracts from the original response
        },
    })
}
```

This change initializes fields directly in the struct literal so field names do not introduce local bindings.

## Test Plan

Adds a regression test with a `value` field followed by another extraction.

```
$ cargo nextest run -p sui-graphql-macros --test extraction_test \
  -- test_field_named_value_does_not_shadow_response_value
```
