### PR TITLE
refactor(graphql): switch from apollo-compiler to bluejay

### DIFF
--- a/crates/sui-graphql-macros/Cargo.toml
+++ b/crates/sui-graphql-macros/Cargo.toml
@@ -26,7 +26,9 @@ syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }
 darling = "0.20"
 graphql-parser = "0.4"
 edit-distance = "2.1"
-apollo-compiler = "1.31"
+bluejay-parser = { version = "0.3", features = ["format-errors"] }
+bluejay-printer = "0.3"
+bluejay-validator = { version = "0.3", default-features = false, features = ["one-of-input-objects", "parser-integration"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sui-graphql-macros/src/lib.rs
+++ b/crates/sui-graphql-macros/src/lib.rs
@@ -337,7 +337,7 @@ pub fn derive_query_response(input: TokenStream) -> TokenStream {
 ///
 /// On a syntactically or semantically invalid input (unknown field, wrong
 /// argument type, undefined variable, etc.) the macro emits one
-/// `compile_error!` per apollo-compiler diagnostic, so the offending call
+/// `compile_error!` per Bluejay diagnostic, so the offending call
 /// site fails to build with the diagnostic text inline.
 #[proc_macro]
 pub fn graphql_query(input: TokenStream) -> TokenStream {

--- a/crates/sui-graphql-macros/src/query.rs
+++ b/crates/sui-graphql-macros/src/query.rs
@@ -2,11 +2,10 @@
 //! canonical formatting of GraphQL queries and mutations against the embedded
 //! Sui schema.
 //!
-//! Validation is delegated to `apollo-compiler`, which performs full GraphQL
-//! spec validation (selection set against schema, argument types, fragment
-//! shapes, variable usage, etc.). On success, the macro emits a `&'static str`
-//! literal containing the canonically formatted query. On failure, every
-//! diagnostic becomes a `syn::Error` anchored at the input literal's span.
+//! Parsing, validation, and printing are delegated to Bluejay. On success, the
+//! macro emits a `&'static str` literal containing the canonically formatted
+//! query. On failure, every diagnostic becomes a `syn::Error` anchored at the
+//! input literal's span.
 //!
 //! The macro is intentionally decoupled from any consumer crate: it produces
 //! a plain string literal so callers can wrap it in their own type. The
@@ -16,40 +15,65 @@
 
 use std::sync::LazyLock;
 
-use apollo_compiler::ExecutableDocument;
-use apollo_compiler::Schema;
-use apollo_compiler::validation::Valid;
+use bluejay_parser::Error as BluejayError;
+use bluejay_parser::ast::Parse;
+use bluejay_parser::ast::definition::DefinitionDocument;
+use bluejay_parser::ast::definition::SchemaDefinition;
+use bluejay_parser::ast::executable::ExecutableDocument;
+use bluejay_parser::error::Location;
+use bluejay_printer::executable::ExecutableDocumentPrinter;
+use bluejay_validator::definition::BuiltinRulesValidator as SchemaValidator;
+use bluejay_validator::executable::Cache;
+use bluejay_validator::executable::document::BuiltinRulesValidator as ExecutableValidator;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::LitStr;
 
-/// Diagnostic label for the embedded SDL. apollo-compiler embeds this string
-/// into its error messages (e.g. `error at <sui schema>:42:5`); it does not
-/// open any file. The actual SDL bytes come from [`crate::schema::SCHEMA_SDL`].
+/// Diagnostic label for the embedded SDL. Bluejay embeds this string into
+/// formatted schema errors; it does not open any file. The actual SDL bytes
+/// come from [`crate::schema::SCHEMA_SDL`].
 const SCHEMA_DIAGNOSTIC_LABEL: &str = "<sui schema>";
 
-/// Diagnostic label for the user's query string passed to `graphql!`. Same
-/// idea as [`SCHEMA_DIAGNOSTIC_LABEL`]: a string that appears in apollo's
-/// error messages, not a file path.
-const QUERY_DIAGNOSTIC_LABEL: &str = "<graphql! input>";
+/// The parsed `SCHEMA_SDL` document.
+///
+/// Bluejay's schema representation borrows its parsed definition document, so
+/// the two values are cached separately. The SDL itself is embedded with a
+/// `'static` lifetime, and proc macros are loaded once per build, allowing both
+/// caches to be reused for every `graphql_query!` call.
+static SCHEMA_DOCUMENT: LazyLock<Result<DefinitionDocument<'static>, String>> =
+    LazyLock::new(|| {
+        DefinitionDocument::parse(crate::schema::SCHEMA_SDL)
+            .map_err(|errors| format_schema_errors("parse", errors))
+    });
 
-/// `SCHEMA_SDL` parsed and validated into a form that can type-check incoming
-/// queries.
-///
-/// Cached for the lifetime of a single `cargo build`: parsing the full SDL is
-/// non-trivial, and proc macros are loaded once per build, so we parse on
-/// first use and reuse the result for every later `graphql!` call.
-///
-/// `Valid<Schema>` is apollo-compiler's marker that the schema itself is
-/// internally consistent; `ExecutableDocument::parse_and_validate` requires
-/// that proof. The `Result<_, String>` shape is what `LazyLock` needs (the
-/// cell value must be `Sync` and shareable across reads); if SDL parsing ever
-/// fails the cached message is reported at every call site.
-static VALIDATED_SCHEMA: LazyLock<Result<Valid<Schema>, String>> = LazyLock::new(|| {
-    Schema::parse_and_validate(crate::schema::SCHEMA_SDL, SCHEMA_DIAGNOSTIC_LABEL)
-        .map_err(|e| format!("Failed to parse Sui GraphQL schema: {e}"))
-});
+/// The resolved and validated Sui schema used to type-check incoming queries.
+static VALIDATED_SCHEMA: LazyLock<Result<SchemaDefinition<'static>, String>> =
+    LazyLock::new(|| {
+        let document = SCHEMA_DOCUMENT.as_ref().map_err(Clone::clone)?;
+        let schema = SchemaDefinition::try_from(document)
+            .map_err(|errors| format_schema_errors("resolve", errors))?;
+        let errors = SchemaValidator::validate(&schema).collect::<Vec<_>>();
+
+        if errors.is_empty() {
+            Ok(schema)
+        } else {
+            Err(format_schema_errors("validate", errors))
+        }
+    });
+
+fn format_schema_errors<E>(action: &str, errors: impl IntoIterator<Item = E>) -> String
+where
+    E: Into<BluejayError>,
+{
+    let formatted = BluejayError::format_errors(
+        crate::schema::SCHEMA_SDL,
+        Some(SCHEMA_DIAGNOSTIC_LABEL),
+        errors,
+    );
+
+    format!("Failed to {action} Sui GraphQL schema:\n{formatted}")
+}
 
 pub fn expand(input: TokenStream) -> TokenStream {
     match expand_impl(input) {
@@ -69,35 +93,64 @@ fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
 
     let schema = VALIDATED_SCHEMA
         .as_ref()
-        .map_err(|e| syn::Error::new(proc_macro2::Span::call_site(), e.clone()))?;
+        .map_err(|error| syn::Error::new(proc_macro2::Span::call_site(), error.clone()))?;
 
-    match ExecutableDocument::parse_and_validate(schema, source.as_str(), QUERY_DIAGNOSTIC_LABEL) {
-        Ok(valid) => {
-            let formatted = valid.to_string();
-            Ok(quote!(#formatted))
-        }
-        Err(with_errors) => {
-            let mut combined: Option<syn::Error> = None;
-            for diag in with_errors.errors.iter() {
-                let msg = match diag.line_column_range() {
-                    Some(range) => format!(
-                        "GraphQL [line {}, col {}]: {}",
-                        range.start.line, range.start.column, diag.error
-                    ),
-                    None => format!("GraphQL: {}", diag.error),
-                };
-                let err = syn::Error::new(proc_macro2::Span::call_site(), msg);
-                match &mut combined {
-                    Some(existing) => existing.combine(err),
-                    None => combined = Some(err),
-                }
-            }
-            Err(combined.unwrap_or_else(|| {
-                syn::Error::new(
-                    proc_macro2::Span::call_site(),
-                    "GraphQL validation failed with no diagnostics",
-                )
-            }))
+    let document = ExecutableDocument::parse(source.as_str()).map_err(|errors| {
+        combine_query_errors(source.as_str(), errors).unwrap_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "GraphQL parsing failed with no diagnostics",
+            )
+        })
+    })?;
+
+    let cache = Cache::new(&document, schema);
+    if let Some(error) = combine_query_errors(
+        source.as_str(),
+        ExecutableValidator::validate(&document, schema, &cache),
+    ) {
+        return Err(error);
+    }
+
+    let formatted = ExecutableDocumentPrinter::to_string(&document);
+    Ok(quote!(#formatted))
+}
+
+fn combine_query_errors<E>(source: &str, errors: impl IntoIterator<Item = E>) -> Option<syn::Error>
+where
+    E: Into<BluejayError>,
+{
+    let mut combined: Option<syn::Error> = None;
+
+    for error in errors {
+        let error = error.into();
+        let message = error.message().to_owned();
+        let graph_errors = BluejayError::into_graphql_errors(source, [error]);
+        let graph_error = graph_errors.first();
+
+        // Parser errors use a generic top-level message and put the useful
+        // detail in their primary annotation. Validation errors have a useful
+        // top-level message already, so retain it.
+        let message = match graph_error {
+            Some(error) if message == "Parse error" => error.message.to_string(),
+            _ => message,
+        };
+
+        let message = if let Some(Location { line, col }) =
+            graph_error.and_then(|error| error.locations.first())
+        {
+            format!("GraphQL [line {}, col {}]: {message}", line, col)
+        } else {
+            format!("GraphQL: {message}")
+        };
+
+        let error = syn::Error::new(proc_macro2::Span::call_site(), message);
+        if let Some(existing) = &mut combined {
+            existing.combine(error);
+        } else {
+            combined = Some(error);
         }
     }
+
+    combined
 }

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_invalid_syntax.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_invalid_syntax.stderr
@@ -1,4 +1,4 @@
-error: GraphQL [line 1, col 24]: syntax error: expected R_CURLY, got EOF
+error: GraphQL [line 1, col 24]: Unexpected EOF
  --> tests/compile/graphql_query_invalid_syntax.rs:5:17
   |
 5 | const Q: &str = graphql_query!("query { chainIdentifier");

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.rs
@@ -1,5 +1,5 @@
 //! trybuild compile-fail: a mix of one valid field and two invalid ones
-//! should produce two separate rustc errors (one per apollo diagnostic), not
+//! should produce two separate rustc errors (one per Bluejay diagnostic), not
 //! a single combined message.
 
 use sui_graphql_macros::graphql_query;

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_errors.stderr
@@ -1,4 +1,4 @@
-error: GraphQL [line 3, col 9]: type `Query` does not have a field `foo`
+error: GraphQL [line 3, col 9]: Field `foo` does not exist on type `Query`
   --> tests/compile/graphql_query_multiple_errors.rs:7:17
    |
  7 |   const Q: &str = graphql_query!(
@@ -13,7 +13,7 @@ error: GraphQL [line 3, col 9]: type `Query` does not have a field `foo`
    |
    = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: GraphQL [line 4, col 9]: type `Query` does not have a field `bar`
+error: GraphQL [line 4, col 9]: Field `bar` does not exist on type `Query`
   --> tests/compile/graphql_query_multiple_errors.rs:7:17
    |
  7 |   const Q: &str = graphql_query!(

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_undefined_variable.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_undefined_variable.stderr
@@ -1,4 +1,4 @@
-error: GraphQL [line 2, col 25]: variable `$id` is not defined
+error: GraphQL [line 2, col 25]: Variable $id not defined in anonymous operation
   --> tests/compile/graphql_query_undefined_variable.rs:5:17
    |
  5 |   const Q: &str = graphql_query!(

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_unknown_field.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_unknown_field.stderr
@@ -1,4 +1,4 @@
-error: GraphQL [line 1, col 9]: type `Query` does not have a field `chainIdentifierr`
+error: GraphQL [line 1, col 9]: Field `chainIdentifierr` does not exist on type `Query`
  --> tests/compile/graphql_query_unknown_field.rs:5:17
   |
 5 | const Q: &str = graphql_query!("query { chainIdentifierr }");

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_variable_typo.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_variable_typo.stderr
@@ -1,4 +1,4 @@
-error: GraphQL [line 1, col 7]: unused variable: `$id`
+error: GraphQL [line 2, col 25]: Variable $idd not defined in anonymous operation
   --> tests/compile/graphql_query_variable_typo.rs:6:17
    |
  6 |   const Q: &str = graphql_query!(
@@ -13,7 +13,7 @@ error: GraphQL [line 1, col 7]: unused variable: `$id`
    |
    = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: GraphQL [line 2, col 25]: variable `$idd` is not defined
+error: GraphQL [line 1, col 7]: Variable definition $id not used
   --> tests/compile/graphql_query_variable_typo.rs:6:17
    |
  6 |   const Q: &str = graphql_query!(


### PR DESCRIPTION
## Description

Use `bluejay` for GraphQL query parsing and validation in the macro, instead of `apollo-parser`. This cuts down the number of dependencies pulled in by the macro (inclusive) from 74 to 39 (a reduction of almost half -- 35 dependencies removed).

`bluejay` is the GraphQL stack from Shopify. It offers the same functionality modulo error message wording, but with less of a hit on build times.

A reduction of 35 dependencies makes a big difference to a project like jellyfish.

## Test plan

Run existing tests:

```
cargo nextest run -p sui-graphql-macros
```

Check dependency tree:

```
$ cargo tree -p sui-graphql-macros -e normal --prefix none \
     | sed 's/ (\*)$//' \
     | sort -u \
     | wc -l
39
```