### PR TITLE
feat(graphql): compose queries from multiple sources

### DIFF
--- a/crates/sui-graphql-macros/Cargo.toml
+++ b/crates/sui-graphql-macros/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = [
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }
 darling = "0.20"

--- a/crates/sui-graphql-macros/src/lib.rs
+++ b/crates/sui-graphql-macros/src/lib.rs
@@ -335,10 +335,27 @@ pub fn derive_query_response(input: TokenStream) -> TokenStream {
 /// Validate a GraphQL query or mutation against the embedded Sui schema at
 /// compile time and return it as a `&'static str`.
 ///
+/// One or more sources can be supplied. An inline source is a string literal;
+/// prefix a path with `@` to load it from a UTF-8 file relative to the Rust
+/// source file containing the macro invocation. Sources are concatenated in
+/// order before the complete document is validated, allowing operations and
+/// fragments to be kept separately:
+///
+/// ```ignore
+/// const QUERY: &str = graphql_query!(
+///     @"queries/get-chain.graphql",
+///     @"queries/chain-fragment.graphql",
+/// );
+/// ```
+///
 /// On a syntactically or semantically invalid input (unknown field, wrong
 /// argument type, undefined variable, etc.) the macro emits one
-/// `compile_error!` per Bluejay diagnostic, so the offending call
-/// site fails to build with the diagnostic text inline.
+/// `compile_error!` per Bluejay diagnostic, so the offending call site fails to
+/// build with the diagnostic text inline.
+///
+/// Inline inputs must be literals. A procedural macro runs before Rust name
+/// resolution and therefore cannot read the value behind a path to a Rust
+/// string constant while retaining compile-time GraphQL validation.
 #[proc_macro]
 pub fn graphql_query(input: TokenStream) -> TokenStream {
     query::expand(input)

--- a/crates/sui-graphql-macros/src/query.rs
+++ b/crates/sui-graphql-macros/src/query.rs
@@ -13,10 +13,12 @@
 //! inside a `ValidatedQuery` constructor, but this proc macro itself has no
 //! dependency on or knowledge of that type.
 
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use bluejay_parser::Error as BluejayError;
-use bluejay_parser::ast::Parse;
+use bluejay_parser::ast::Parse as _;
 use bluejay_parser::ast::definition::DefinitionDocument;
 use bluejay_parser::ast::definition::SchemaDefinition;
 use bluejay_parser::ast::executable::ExecutableDocument;
@@ -29,6 +31,11 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::LitStr;
+use syn::Token;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
 
 /// Diagnostic label for the embedded SDL. Bluejay embeds this string into
 /// formatted schema errors; it does not open any file. The actual SDL bytes
@@ -62,17 +69,21 @@ static VALIDATED_SCHEMA: LazyLock<Result<SchemaDefinition<'static>, String>> =
         }
     });
 
-fn format_schema_errors<E>(action: &str, errors: impl IntoIterator<Item = E>) -> String
-where
-    E: Into<BluejayError>,
-{
-    let formatted = BluejayError::format_errors(
-        crate::schema::SCHEMA_SDL,
-        Some(SCHEMA_DIAGNOSTIC_LABEL),
-        errors,
-    );
+/// A piece of GraphQL source supplied inline or loaded from a file.
+enum Source {
+    Inline(LitStr),
+    File(LitStr),
+}
 
-    format!("Failed to {action} Sui GraphQL schema:\n{formatted}")
+impl Parse for Source {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        if input.peek(Token![@]) {
+            input.parse::<Token![@]>()?;
+            input.parse().map(Self::File)
+        } else {
+            input.parse().map(Self::Inline)
+        }
+    }
 }
 
 pub fn expand(input: TokenStream) -> TokenStream {
@@ -85,35 +96,6 @@ pub fn expand(input: TokenStream) -> TokenStream {
             quote!({ #compile_error "" }).into()
         }
     }
-}
-
-fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
-    let lit: LitStr = syn::parse(input)?;
-    let source = lit.value();
-
-    let schema = VALIDATED_SCHEMA
-        .as_ref()
-        .map_err(|error| syn::Error::new(proc_macro2::Span::call_site(), error.clone()))?;
-
-    let document = ExecutableDocument::parse(source.as_str()).map_err(|errors| {
-        combine_query_errors(source.as_str(), errors).unwrap_or_else(|| {
-            syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "GraphQL parsing failed with no diagnostics",
-            )
-        })
-    })?;
-
-    let cache = Cache::new(&document, schema);
-    if let Some(error) = combine_query_errors(
-        source.as_str(),
-        ExecutableValidator::validate(&document, schema, &cache),
-    ) {
-        return Err(error);
-    }
-
-    let formatted = ExecutableDocumentPrinter::to_string(&document);
-    Ok(quote!(#formatted))
 }
 
 fn combine_query_errors<E>(source: &str, errors: impl IntoIterator<Item = E>) -> Option<syn::Error>
@@ -153,4 +135,101 @@ where
     }
 
     combined
+}
+
+fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
+    let sources = Punctuated::<Source, Token![,]>::parse_terminated.parse(input)?;
+    if sources.is_empty() {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "expected at least one GraphQL source",
+        ));
+    }
+
+    // Concatenate exactly like Rust's `concat!`: callers can split a document
+    // wherever they like, and fragments can live in separate sources. The
+    // complete document is still parsed, validated, and formatted as one unit.
+    let mut source = String::new();
+    let mut dependencies = Vec::new();
+    for input in sources {
+        match input {
+            Source::Inline(literal) => source.push_str(&literal.value()),
+            Source::File(literal) => {
+                let path = source_relative(&literal)?;
+                let contents = std::fs::read_to_string(&path).map_err(|error| {
+                    syn::Error::new(
+                        literal.span(),
+                        format!(
+                            "failed to read GraphQL source from '{}': {error}",
+                            path.display()
+                        ),
+                    )
+                })?;
+
+                source.push_str(&contents);
+                dependencies.push(literal);
+            }
+        }
+    }
+
+    let schema = VALIDATED_SCHEMA
+        .as_ref()
+        .map_err(|error| syn::Error::new(proc_macro2::Span::call_site(), error.clone()))?;
+
+    let document = ExecutableDocument::parse(source.as_str()).map_err(|errors| {
+        combine_query_errors(source.as_str(), errors).unwrap_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "GraphQL parsing failed with no diagnostics",
+            )
+        })
+    })?;
+
+    let cache = Cache::new(&document, schema);
+    if let Some(error) = combine_query_errors(
+        source.as_str(),
+        ExecutableValidator::validate(&document, schema, &cache),
+    ) {
+        return Err(error);
+    }
+
+    let formatted = ExecutableDocumentPrinter::to_string(&document);
+    // Keep an `include_str!` for every loaded source in the expansion so
+    // rustc and Cargo rebuild when one of them changes.
+    Ok(quote!({
+        #(const _: &str = ::core::include_str!(#dependencies);)*
+        #formatted
+    }))
+}
+
+fn format_schema_errors<E>(action: &str, errors: impl IntoIterator<Item = E>) -> String
+where
+    E: Into<BluejayError>,
+{
+    let formatted = BluejayError::format_errors(
+        crate::schema::SCHEMA_SDL,
+        Some(SCHEMA_DIAGNOSTIC_LABEL),
+        errors,
+    );
+
+    format!("Failed to {action} Sui GraphQL schema:\n{formatted}")
+}
+
+/// Interpret `path` as a path relative to the source file containing the macro invocation.
+fn source_relative(literal: &LitStr) -> Result<PathBuf, syn::Error> {
+    let value = literal.value();
+    let path = Path::new(&value);
+    if path.is_absolute() {
+        return Ok(path.to_owned());
+    }
+
+    let source = literal.span().local_file();
+    let Some(source_dir) = source.as_ref().and_then(|file| file.parent()) else {
+        return Err(syn::Error::new(
+            literal.span(),
+            "cannot resolve GraphQL path relative to source file",
+        ));
+    };
+
+    Ok(source_dir.join(path))
 }

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_strings.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_multiple_strings.rs
@@ -1,0 +1,14 @@
+//! trybuild compile-pass: operations and fragments can be supplied as separate literals.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!(
+    "query { ...ChainIdentifier }",
+    "fragment ChainIdentifier on Query { chainIdentifier }",
+);
+const SPLIT_TOKEN: &str = graphql_query!("query { chainIdent", "ifier }");
+
+fn main() {
+    assert!(Q.contains("chainIdentifier"));
+    assert!(SPLIT_TOKEN.contains("chainIdentifier"));
+}

--- a/crates/sui-graphql-macros/tests/compile_tests.rs
+++ b/crates/sui-graphql-macros/tests/compile_tests.rs
@@ -59,6 +59,7 @@ fn compile_tests() {
     t.pass("tests/compile/graphql_query_simple.rs");
     t.pass("tests/compile/graphql_query_with_variables.rs");
     t.pass("tests/compile/graphql_query_mutation.rs");
+    t.pass("tests/compile/graphql_query_multiple_strings.rs");
     t.compile_fail("tests/compile/graphql_query_unknown_field.rs");
     t.compile_fail("tests/compile/graphql_query_undefined_variable.rs");
     t.compile_fail("tests/compile/graphql_query_variable_typo.rs");

--- a/crates/sui-graphql-macros/tests/graphql_query_test.rs
+++ b/crates/sui-graphql-macros/tests/graphql_query_test.rs
@@ -1,0 +1,17 @@
+use sui_graphql_macros::graphql_query;
+
+const FILE_QUERY: &str = graphql_query!(
+    @"queries/chain_identifier_query.graphql",
+    @"queries/chain_identifier_fragment.graphql",
+);
+
+const MIXED_QUERY: &str = graphql_query!(
+    "query { ...ChainIdentifier }",
+    @"queries/chain_identifier_fragment.graphql",
+);
+
+#[test]
+fn file_sources_are_loaded_and_formatted() {
+    assert_eq!(FILE_QUERY, MIXED_QUERY);
+    assert!(FILE_QUERY.contains("chainIdentifier"));
+}

--- a/crates/sui-graphql-macros/tests/queries/chain_identifier_fragment.graphql
+++ b/crates/sui-graphql-macros/tests/queries/chain_identifier_fragment.graphql
@@ -1,0 +1,3 @@
+fragment ChainIdentifier on Query {
+    chainIdentifier
+}

--- a/crates/sui-graphql-macros/tests/queries/chain_identifier_query.graphql
+++ b/crates/sui-graphql-macros/tests/queries/chain_identifier_query.graphql
@@ -1,0 +1,3 @@
+query {
+    ...ChainIdentifier
+}


### PR DESCRIPTION

## Description

GraphQL operations often share fragments, but `graphql_query!` previously accepted one literal, forcing operations and reusable fragments into the same source.

Allow comma-separated inline literals and `@"..."` file sources. Concatenate all sources before parsing, validation, and canonical formatting. File paths follow `include_str!` semantics by resolving relative to the invoking Rust source file, and generated `include_str!` sentinels keep files in Cargo's dependency graph.

## Test Plan

Added compile-pass coverage for multiple literals, including a token split across source boundaries. Added integration coverage for file-only and mixed inline/file queries.
