### PR TITLE
Add gRPC pagination and resumption helpers

### DIFF
--- a/crates/sui-rpc/CHANGELOG.md
+++ b/crates/sui-rpc/CHANGELOG.md
@@ -1,6 +1,16 @@
+# Unreleased
+
+## Added
+
+- add finite `Client::list_{checkpoints,transactions,events}` streams that yield generated
+  responses unchanged and automatically continue `ItemLimit` and `ScanLimit` pagination.
+- add resumable `Client::stream_*` frames with `Tip`, `Checkpoint`, and opaque `Resume`
+  starts, plus live-tip `Subscribe` and indexed-tip `Poll` delivery.
+
 # [0.3.2] - 2026-07-16
 
 ## Added
+
 - [#256] [#264] [#265] [#278] add filtered `ListCheckpoints`,
   `ListTransactions`, and `ListEvents` RPCs to the v2 `LedgerService`,
   filtered `SubscribeTransactions` and `SubscribeEvents` RPCs to the v2
@@ -29,6 +39,7 @@
   archive-first historical reads, behind the `unstable` feature
 
 ## Changed
+
 - [`668c7a3c`] [`ab33fca8`] harden the shared HTTP/2 connection against
   flow-control starvation: `Client::new` now sets explicit stream and
   connection receive windows (overridable with
@@ -44,6 +55,7 @@
   in the staking and execute-and-wait helpers
 
 ## Fixed
+
 - [`fb3d25a2`] enforce the deadline set with `tonic::Request::set_timeout`
   across the whole response body, so a per-call deadline now bounds the
   entire call instead of only the response-headers phase
@@ -74,7 +86,6 @@
 [#283]: https://github.com/MystenLabs/sui-rust-sdk/pull/283
 [#286]: https://github.com/MystenLabs/sui-rust-sdk/pull/286
 [#287]: https://github.com/MystenLabs/sui-rust-sdk/pull/287
-
 [`f3673da1`]: https://github.com/mystenlabs/sui-rust-sdk/commit/f3673da1
 [`3ef25b50`]: https://github.com/mystenlabs/sui-rust-sdk/commit/3ef25b50
 [`57343980`]: https://github.com/mystenlabs/sui-rust-sdk/commit/57343980
@@ -101,6 +112,7 @@
 # [0.3.1] - 2026-04-13
 
 ## Added
+
 - [#233] make `Client::calculate_rewards` and
   `Client::get_validator_address_by_pool_id` public
 - [#235] allow constructing a `Client` from a configured tonic `Endpoint`
@@ -109,6 +121,7 @@
   arbitrary `tower::Layer`
 
 ## Changed
+
 - [#236] update the default endpoint configuration
 
 [#233]: https://github.com/MystenLabs/sui-rust-sdk/pull/233
@@ -119,12 +132,14 @@
 # [0.3.0] - 2026-03-23
 
 ## Added
+
 - [#216] add support for `Object.display` and `SimulateTransactionResponse.suggested_gas_price`
 - [#231] add proto support for `AccumulatorValue::EventDigest` and `AccumulatorValue::IntegerTuple`
   for authenticated event streams
 - add `Unimplemented*` default stubs for all generated gRPC service traits
 
 ## Fixed
+
 - [#228] box `FieldViolation` in `TryFromProtoError` to reduce stack size
 - [#212] handle the case where a transaction has already been executed
 - support partial errors in `Object.display`
@@ -137,6 +152,7 @@
 # [0.2.2] - 2026-01-20
 
 ## Added
+
 - [#202] add support for TransactionKind::ProgrammableSystemTransaction
 - [#204] add support for EndOfEpochTransactionKind::WriteAccumulatorStorageCost
 
@@ -146,6 +162,7 @@
 # [0.2.1] - 2026-01-07
 
 ## Added
+
 - [#185] add `address_balance` and `coin_balance` fields to Balance message
 
 [#185]: https://github.com/MystenLabs/sui-rust-sdk/pull/185
@@ -153,6 +170,7 @@
 # [0.2.0] - 2026-01-05
 
 ## Added
+
 - Added support for address balances [#179]
 - Added support for address aliases [#177]
 - Added support for CheckpointContents V2 [#180]
@@ -164,11 +182,13 @@
 # [0.1.1] - 2025-12-11
 
 ## Added
+
 - Added new move vm adapter error variants
 
 # [0.1.0] - 2025-11-07
 
 ## Changed
+
 - Updated to rust 2024 edition [#171]
 - Updated to tonic/prost 0.14 [#168]
 - Removed `Into` requirement for setters of primitive types [`ec1547f1`]
@@ -183,6 +203,7 @@
 # [0.0.8] - 2025-10-03
 
 ## Added
+
 - Support for field path builders for proto messages
 - Support for field accessors and builder methods for proto messages
 - Add `Client::execute_transaction_and_wait_for_checkpoint` method

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/checkpoint.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/checkpoint.rs
@@ -1,0 +1,75 @@
+use tonic::Request;
+use tonic::codegen::BoxStream;
+
+use super::super::super::Client;
+use super::super::super::Result;
+use super::super::observability::LedgerStreamFamily;
+use super::ListScanDirection;
+use super::RpcFuture;
+use super::SubscriptionAdapter;
+use crate::proto::sui::rpc::v2::ListCheckpointsRequest;
+use crate::proto::sui::rpc::v2::ListCheckpointsResponse;
+use crate::proto::sui::rpc::v2::QueryEnd;
+use crate::proto::sui::rpc::v2::QueryOptions;
+use crate::proto::sui::rpc::v2::Watermark;
+
+pub(in crate::client::ledger_streams) struct CheckpointAdapter;
+
+impl SubscriptionAdapter for CheckpointAdapter {
+    const FAMILY: LedgerStreamFamily = LedgerStreamFamily::Checkpoint;
+
+    type Cursor = u64;
+    type ListRequest = ListCheckpointsRequest;
+    type ListResponse = ListCheckpointsResponse;
+    fn options(request: &Self::ListRequest) -> Option<&QueryOptions> {
+        request.options.as_ref()
+    }
+
+    fn options_mut(request: &mut Self::ListRequest) -> &mut QueryOptions {
+        request.options.get_or_insert_with(QueryOptions::default)
+    }
+
+    fn start_checkpoint(request: &Self::ListRequest) -> Option<u64> {
+        request.start_checkpoint
+    }
+
+    fn end_checkpoint(request: &Self::ListRequest) -> Option<u64> {
+        request.end_checkpoint
+    }
+    fn validate_checkpoint_bound(
+        request: &Self::ListRequest,
+        direction: ListScanDirection,
+        checkpoint: Option<u64>,
+    ) -> Result<()> {
+        super::validate_typed_checkpoint_bound(
+            request.start_checkpoint,
+            request.end_checkpoint,
+            direction,
+            checkpoint,
+        )
+    }
+
+    fn extract_metadata(
+        response: &Self::ListResponse,
+    ) -> (bool, Option<&Watermark>, Option<&QueryEnd>) {
+        (
+            response.checkpoint.is_some(),
+            response.watermark.as_ref(),
+            response.end.as_ref(),
+        )
+    }
+
+    fn dispatch_list(
+        mut client: Client,
+        request: Request<Self::ListRequest>,
+    ) -> RpcFuture<Self::ListResponse> {
+        Box::pin(async move {
+            let stream = client
+                .ledger_client()
+                .list_checkpoints(request)
+                .await?
+                .into_inner();
+            Ok(Box::pin(stream) as BoxStream<Self::ListResponse>)
+        })
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/checkpoint.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/checkpoint.rs
@@ -1,26 +1,59 @@
 use tonic::Request;
+use tonic::Status;
 use tonic::codegen::BoxStream;
 
 use super::super::super::Client;
 use super::super::super::Result;
 use super::super::observability::LedgerStreamFamily;
+use super::super::types::CheckpointStreamFrame;
+use super::CHECKPOINT_CURSOR_OVERFLOW;
+use super::ListResponseParts;
 use super::ListScanDirection;
+use super::LiveFrame;
+use super::PositionedItem;
+use super::Progress;
 use super::RpcFuture;
 use super::SubscriptionAdapter;
+use crate::proto::sui::rpc::v2::Checkpoint;
 use crate::proto::sui::rpc::v2::ListCheckpointsRequest;
 use crate::proto::sui::rpc::v2::ListCheckpointsResponse;
 use crate::proto::sui::rpc::v2::QueryEnd;
 use crate::proto::sui::rpc::v2::QueryOptions;
+use crate::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
+use crate::proto::sui::rpc::v2::SubscribeCheckpointsResponse;
 use crate::proto::sui::rpc::v2::Watermark;
 
 pub(in crate::client::ledger_streams) struct CheckpointAdapter;
 
 impl SubscriptionAdapter for CheckpointAdapter {
     const FAMILY: LedgerStreamFamily = LedgerStreamFamily::Checkpoint;
+    const REQUIRED_READ_MASK_FIELDS: &'static [&'static str] = &["sequence_number"];
+    const READ_MASK_REQUIREMENT: &'static str =
+        "read_mask must include \"sequence_number\" or \"*\"";
 
+    type Item = PositionedItem<Checkpoint, u64>;
+    type ItemPosition = u64;
     type Cursor = u64;
+    type Output = CheckpointStreamFrame;
     type ListRequest = ListCheckpointsRequest;
     type ListResponse = ListCheckpointsResponse;
+    type SubscribeRequest = SubscribeCheckpointsRequest;
+    type SubscribeResponse = SubscribeCheckpointsResponse;
+
+    fn list_read_mask(request: &Self::ListRequest) -> Option<&prost_types::FieldMask> {
+        request.read_mask.as_ref()
+    }
+
+    fn list_request_from_subscribe(request: &Self::SubscribeRequest) -> Self::ListRequest {
+        ListCheckpointsRequest {
+            read_mask: request.read_mask.clone(),
+            filter: request.filter.clone(),
+            start_checkpoint: None,
+            end_checkpoint: None,
+            options: None,
+        }
+    }
+
     fn options(request: &Self::ListRequest) -> Option<&QueryOptions> {
         request.options.as_ref()
     }
@@ -33,9 +66,42 @@ impl SubscriptionAdapter for CheckpointAdapter {
         request.start_checkpoint
     }
 
+    fn set_start_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>) {
+        request.start_checkpoint = checkpoint;
+    }
+
     fn end_checkpoint(request: &Self::ListRequest) -> Option<u64> {
         request.end_checkpoint
     }
+
+    fn set_end_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>) {
+        request.end_checkpoint = checkpoint;
+    }
+
+    fn set_ascending_resume(
+        request: &mut Self::ListRequest,
+        progress: &Progress<Self::Cursor>,
+    ) -> Result<()> {
+        request.start_checkpoint = Some(
+            progress
+                .cursor
+                .checked_add(1)
+                .ok_or_else(|| Status::out_of_range(CHECKPOINT_CURSOR_OVERFLOW))?,
+        );
+        Self::options_mut(request).after = None;
+        Ok(())
+    }
+
+    fn request_resume_position(request: &Self::ListRequest) -> Option<Progress<Self::Cursor>> {
+        request
+            .start_checkpoint
+            .and_then(|start| start.checked_sub(1))
+            .map(|cursor| Progress {
+                cursor,
+                checkpoint: Some(cursor),
+            })
+    }
+
     fn validate_checkpoint_bound(
         request: &Self::ListRequest,
         direction: ListScanDirection,
@@ -48,6 +114,9 @@ impl SubscriptionAdapter for CheckpointAdapter {
             checkpoint,
         )
     }
+    fn item_position(item: &Self::Item) -> &Self::ItemPosition {
+        item.position()
+    }
 
     fn extract_metadata(
         response: &Self::ListResponse,
@@ -57,6 +126,63 @@ impl SubscriptionAdapter for CheckpointAdapter {
             response.watermark.as_ref(),
             response.end.as_ref(),
         )
+    }
+
+    fn split_list(response: Self::ListResponse) -> Result<ListResponseParts<Self>> {
+        let item = response.checkpoint.map(|checkpoint| -> Result<Self::Item> {
+            let position = checkpoint.sequence_number.ok_or_else(|| {
+                Status::data_loss("List checkpoint item is missing its sequence number")
+            })?;
+            Ok(PositionedItem::new(checkpoint, position))
+        });
+        Ok(ListResponseParts {
+            item: item.transpose()?,
+            watermark: response.watermark,
+        })
+    }
+
+    fn item_required(request: &Self::SubscribeRequest) -> bool {
+        request.filter.is_none()
+    }
+
+    fn parse_live(
+        response: Self::SubscribeResponse,
+        item_required: bool,
+    ) -> Result<LiveFrame<Self::Item, Progress<Self::Cursor>>> {
+        let cursor = response.cursor.ok_or_else(|| {
+            Status::data_loss("checkpoint subscription frame is missing its cursor")
+        })?;
+        if response.checkpoint.is_none() && item_required {
+            return Err(Status::data_loss(
+                "unfiltered checkpoint subscription frame is missing its checkpoint",
+            ));
+        }
+        let item = response.checkpoint.map(|checkpoint| -> Result<Self::Item> {
+            let position = checkpoint.sequence_number.ok_or_else(|| {
+                Status::data_loss("checkpoint subscription item is missing its sequence number")
+            })?;
+            if position != cursor {
+                return Err(Status::data_loss(
+                    "checkpoint subscription item sequence does not match its cursor",
+                ));
+            }
+            Ok(PositionedItem::new(checkpoint, position))
+        });
+        Ok(LiveFrame {
+            item: item.transpose()?,
+            progress: Progress {
+                cursor,
+                checkpoint: Some(cursor),
+            },
+        })
+    }
+
+    fn into_output(item: Option<Self::Item>, progress: Progress<Self::Cursor>) -> Self::Output {
+        let checkpoint = item.map(PositionedItem::into_payload);
+        CheckpointStreamFrame {
+            checkpoint,
+            cursor: progress.cursor,
+        }
     }
 
     fn dispatch_list(
@@ -70,6 +196,20 @@ impl SubscriptionAdapter for CheckpointAdapter {
                 .await?
                 .into_inner();
             Ok(Box::pin(stream) as BoxStream<Self::ListResponse>)
+        })
+    }
+
+    fn dispatch_subscribe(
+        mut client: Client,
+        request: Request<Self::SubscribeRequest>,
+    ) -> RpcFuture<Self::SubscribeResponse> {
+        Box::pin(async move {
+            let stream = client
+                .subscription_client()
+                .subscribe_checkpoints(request)
+                .await?
+                .into_inner();
+            Ok(Box::pin(stream) as BoxStream<Self::SubscribeResponse>)
         })
     }
 }

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/event.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/event.rs
@@ -1,0 +1,73 @@
+use prost::bytes::Bytes;
+use tonic::Request;
+use tonic::codegen::BoxStream;
+
+use super::super::super::Client;
+use super::super::super::Result;
+use super::super::observability::LedgerStreamFamily;
+use super::ListScanDirection;
+use super::RpcFuture;
+use super::SubscriptionAdapter;
+use crate::proto::sui::rpc::v2::ListEventsRequest;
+use crate::proto::sui::rpc::v2::ListEventsResponse;
+use crate::proto::sui::rpc::v2::QueryEnd;
+use crate::proto::sui::rpc::v2::QueryOptions;
+use crate::proto::sui::rpc::v2::Watermark;
+
+pub(in crate::client::ledger_streams) struct EventAdapter;
+
+impl SubscriptionAdapter for EventAdapter {
+    const FAMILY: LedgerStreamFamily = LedgerStreamFamily::Event;
+
+    type Cursor = Bytes;
+    type ListRequest = ListEventsRequest;
+    type ListResponse = ListEventsResponse;
+
+    fn options(request: &Self::ListRequest) -> Option<&QueryOptions> {
+        request.options.as_ref()
+    }
+
+    fn options_mut(request: &mut Self::ListRequest) -> &mut QueryOptions {
+        request.options.get_or_insert_with(QueryOptions::default)
+    }
+
+    fn start_checkpoint(request: &Self::ListRequest) -> Option<u64> {
+        request.start_checkpoint
+    }
+
+    fn end_checkpoint(request: &Self::ListRequest) -> Option<u64> {
+        request.end_checkpoint
+    }
+
+    fn validate_checkpoint_bound(
+        _request: &Self::ListRequest,
+        _direction: ListScanDirection,
+        _checkpoint: Option<u64>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn extract_metadata(
+        response: &Self::ListResponse,
+    ) -> (bool, Option<&Watermark>, Option<&QueryEnd>) {
+        (
+            response.event.is_some(),
+            response.watermark.as_ref(),
+            response.end.as_ref(),
+        )
+    }
+
+    fn dispatch_list(
+        mut client: Client,
+        request: Request<Self::ListRequest>,
+    ) -> RpcFuture<Self::ListResponse> {
+        Box::pin(async move {
+            let stream = client
+                .ledger_client()
+                .list_events(request)
+                .await?
+                .into_inner();
+            Ok(Box::pin(stream) as BoxStream<Self::ListResponse>)
+        })
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/event.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/event.rs
@@ -1,27 +1,59 @@
 use prost::bytes::Bytes;
 use tonic::Request;
+use tonic::Status;
 use tonic::codegen::BoxStream;
 
 use super::super::super::Client;
 use super::super::super::Result;
 use super::super::observability::LedgerStreamFamily;
+use super::super::types::EventStreamFrame;
+use super::ListResponseParts;
 use super::ListScanDirection;
+use super::LiveFrame;
+use super::PositionedItem;
+use super::Progress;
 use super::RpcFuture;
 use super::SubscriptionAdapter;
+use super::parse_opaque_live_frame;
+use crate::proto::sui::rpc::v2::Event;
 use crate::proto::sui::rpc::v2::ListEventsRequest;
 use crate::proto::sui::rpc::v2::ListEventsResponse;
 use crate::proto::sui::rpc::v2::QueryEnd;
 use crate::proto::sui::rpc::v2::QueryOptions;
+use crate::proto::sui::rpc::v2::SubscribeEventsRequest;
+use crate::proto::sui::rpc::v2::SubscribeEventsResponse;
 use crate::proto::sui::rpc::v2::Watermark;
 
 pub(in crate::client::ledger_streams) struct EventAdapter;
 
 impl SubscriptionAdapter for EventAdapter {
     const FAMILY: LedgerStreamFamily = LedgerStreamFamily::Event;
+    const REQUIRED_READ_MASK_FIELDS: &'static [&'static str] =
+        &["checkpoint", "transaction_index", "event_index"];
+    const READ_MASK_REQUIREMENT: &'static str = "read_mask must include \"checkpoint\", \"transaction_index\", and \"event_index\" or \"*\"";
 
+    type Item = PositionedItem<Event, (u64, u64, u32)>;
+    type ItemPosition = (u64, u64, u32);
     type Cursor = Bytes;
+    type Output = EventStreamFrame;
     type ListRequest = ListEventsRequest;
     type ListResponse = ListEventsResponse;
+    type SubscribeRequest = SubscribeEventsRequest;
+    type SubscribeResponse = SubscribeEventsResponse;
+
+    fn list_read_mask(request: &Self::ListRequest) -> Option<&prost_types::FieldMask> {
+        request.read_mask.as_ref()
+    }
+
+    fn list_request_from_subscribe(request: &Self::SubscribeRequest) -> Self::ListRequest {
+        ListEventsRequest {
+            read_mask: request.read_mask.clone(),
+            filter: request.filter.clone(),
+            start_checkpoint: None,
+            end_checkpoint: None,
+            options: None,
+        }
+    }
 
     fn options(request: &Self::ListRequest) -> Option<&QueryOptions> {
         request.options.as_ref()
@@ -35,16 +67,45 @@ impl SubscriptionAdapter for EventAdapter {
         request.start_checkpoint
     }
 
+    fn set_start_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>) {
+        request.start_checkpoint = checkpoint;
+    }
+
     fn end_checkpoint(request: &Self::ListRequest) -> Option<u64> {
         request.end_checkpoint
     }
 
+    fn set_end_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>) {
+        request.end_checkpoint = checkpoint;
+    }
+
+    fn set_ascending_resume(
+        request: &mut Self::ListRequest,
+        progress: &Progress<Self::Cursor>,
+    ) -> Result<()> {
+        Self::options_mut(request).after = Some(progress.cursor.clone());
+        Ok(())
+    }
+
+    fn request_resume_position(request: &Self::ListRequest) -> Option<Progress<Self::Cursor>> {
+        request
+            .options
+            .as_ref()
+            .and_then(|options| options.after.clone())
+            .map(|cursor| Progress {
+                cursor,
+                checkpoint: None,
+            })
+    }
     fn validate_checkpoint_bound(
         _request: &Self::ListRequest,
         _direction: ListScanDirection,
         _checkpoint: Option<u64>,
     ) -> Result<()> {
         Ok(())
+    }
+    fn item_position(item: &Self::Item) -> &Self::ItemPosition {
+        item.position()
     }
 
     fn extract_metadata(
@@ -55,6 +116,31 @@ impl SubscriptionAdapter for EventAdapter {
             response.watermark.as_ref(),
             response.end.as_ref(),
         )
+    }
+
+    fn split_list(response: Self::ListResponse) -> Result<ListResponseParts<Self>> {
+        let item = response.event.map(position_event).transpose()?;
+        Ok(ListResponseParts {
+            item,
+            watermark: response.watermark,
+        })
+    }
+
+    fn parse_live(
+        response: Self::SubscribeResponse,
+        _item_required: bool,
+    ) -> Result<LiveFrame<Self::Item, Progress<Self::Cursor>>> {
+        let item = response.event.map(position_event).transpose()?;
+        parse_opaque_live_frame(item, response.watermark)
+    }
+
+    fn into_output(item: Option<Self::Item>, progress: Progress<Self::Cursor>) -> Self::Output {
+        let event = item.map(PositionedItem::into_payload);
+        EventStreamFrame {
+            event,
+            cursor: progress.cursor,
+            covered_checkpoint: progress.checkpoint,
+        }
     }
 
     fn dispatch_list(
@@ -70,4 +156,34 @@ impl SubscriptionAdapter for EventAdapter {
             Ok(Box::pin(stream) as BoxStream<Self::ListResponse>)
         })
     }
+
+    fn dispatch_subscribe(
+        mut client: Client,
+        request: Request<Self::SubscribeRequest>,
+    ) -> RpcFuture<Self::SubscribeResponse> {
+        Box::pin(async move {
+            let stream = client
+                .subscription_client()
+                .subscribe_events(request)
+                .await?
+                .into_inner();
+            Ok(Box::pin(stream) as BoxStream<Self::SubscribeResponse>)
+        })
+    }
+}
+
+fn position_event(event: Event) -> Result<PositionedItem<Event, (u64, u64, u32)>> {
+    let checkpoint = event
+        .checkpoint
+        .ok_or_else(|| Status::data_loss("event item is missing its checkpoint"))?;
+    let transaction_index = event
+        .transaction_index
+        .ok_or_else(|| Status::data_loss("event item is missing its transaction index"))?;
+    let event_index = event
+        .event_index
+        .ok_or_else(|| Status::data_loss("event item is missing its event index"))?;
+    Ok(PositionedItem::new(
+        event,
+        (checkpoint, transaction_index, event_index),
+    ))
 }

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/mod.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/mod.rs
@@ -1,7 +1,9 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use prost::Message;
 use prost::bytes::Bytes;
+use prost_types::FieldMask;
 use tonic::Request;
 use tonic::Status;
 use tonic::codegen::BoxStream;
@@ -22,40 +24,165 @@ mod transaction;
 pub(super) use checkpoint::CheckpointAdapter;
 pub(super) use event::EventAdapter;
 pub(super) use progress::CursorDomain;
+pub(super) use progress::CursorGapUpper;
 pub(super) use progress::Progress;
+pub(super) use progress::ProgressAdvance;
+pub(super) use progress::Recovery;
+pub(super) use progress::RecoveryGap;
 pub(super) use transaction::TransactionAdapter;
+
+const CHECKPOINT_CURSOR_OVERFLOW: &str = "checkpoint subscription cursor cannot be resumed";
+
 pub(super) type RpcFuture<T> = Pin<Box<dyn Future<Output = Result<BoxStream<T>>> + Send + 'static>>;
+
+pub(super) struct PositionedItem<I, P> {
+    payload: I,
+    position: P,
+}
+
+impl<I, P> PositionedItem<I, P> {
+    fn new(payload: I, position: P) -> Self {
+        Self { payload, position }
+    }
+
+    pub(super) fn position(&self) -> &P {
+        &self.position
+    }
+
+    fn into_payload(self) -> I {
+        self.payload
+    }
+}
+
+pub(super) struct ListResponseParts<A: SubscriptionAdapter + ?Sized> {
+    pub(super) item: Option<A::Item>,
+    pub(super) watermark: Option<Watermark>,
+}
+
+pub(super) struct LiveFrame<I, P> {
+    pub(super) item: Option<I>,
+    pub(super) progress: P,
+}
+
+pub(super) fn validate_caller_read_mask<A: SubscriptionAdapter>(
+    read_mask: Option<&FieldMask>,
+) -> Result<()> {
+    let Some(read_mask) = read_mask else {
+        return Err(Status::invalid_argument(A::READ_MASK_REQUIREMENT));
+    };
+    if read_mask.paths.is_empty() {
+        return Err(Status::invalid_argument(A::READ_MASK_REQUIREMENT));
+    }
+    if read_mask.paths.iter().any(|path| path == "*") {
+        return Ok(());
+    }
+    if A::REQUIRED_READ_MASK_FIELDS.iter().all(|required| {
+        read_mask
+            .paths
+            .iter()
+            .any(|path| path.as_str() == *required)
+    }) {
+        Ok(())
+    } else {
+        Err(Status::invalid_argument(A::READ_MASK_REQUIREMENT))
+    }
+}
 
 /// Connects one checkpoint, transaction, or event protocol family to the shared driver.
 pub(super) trait SubscriptionAdapter: Send + Sync + 'static {
     const FAMILY: LedgerStreamFamily;
+    /// Scalar payload fields the state machine needs for ordering, deduplication, and restart.
+    const REQUIRED_READ_MASK_FIELDS: &'static [&'static str];
+    /// Error returned when a caller mask omits required identity fields.
+    const READ_MASK_REQUIREMENT: &'static str;
+
+    type Item: Send + 'static;
+    /// Ledger identity used for ordering, deduplication, and resume.
+    type ItemPosition: Clone + Eq + Ord + Send + 'static;
+    /// Cursor carried by payload and progress-only frames.
     type Cursor: CursorDomain;
+    type Output: Send + 'static;
     type ListRequest: Clone + Send + Sync + 'static;
     type ListResponse: Send + 'static;
+    type SubscribeRequest: Clone + Send + 'static;
+    type SubscribeResponse: Message + Send + 'static;
 
+    /// Returns the caller's List projection unchanged.
+    fn list_read_mask(request: &Self::ListRequest) -> Option<&FieldMask>;
+    /// Builds an unbounded ascending recovery request from a live request.
+    fn list_request_from_subscribe(request: &Self::SubscribeRequest) -> Self::ListRequest;
     /// Returns the List request's pagination and ordering options when present.
     fn options(request: &Self::ListRequest) -> Option<&QueryOptions>;
     /// Returns mutable List pagination and ordering options, inserting defaults when absent.
     fn options_mut(request: &mut Self::ListRequest) -> &mut QueryOptions;
     /// Returns the List request's inclusive lower checkpoint bound.
     fn start_checkpoint(request: &Self::ListRequest) -> Option<u64>;
+    /// Sets the List request's inclusive lower checkpoint bound.
+    fn set_start_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>);
     /// Returns the List request's exclusive upper checkpoint bound.
     fn end_checkpoint(request: &Self::ListRequest) -> Option<u64>;
+    /// Sets the List request's exclusive upper checkpoint bound.
+    fn set_end_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>);
+    /// Advances an ascending List request strictly past `progress`.
+    fn set_ascending_resume(
+        request: &mut Self::ListRequest,
+        progress: &Progress<Self::Cursor>,
+    ) -> Result<()>;
+    /// Returns progress covered by the request's resume bound, if any.
+    fn request_resume_position(request: &Self::ListRequest) -> Option<Progress<Self::Cursor>>;
     /// Validates a `CheckpointBound` ending against the request bounds.
     fn validate_checkpoint_bound(
         request: &Self::ListRequest,
         direction: ListScanDirection,
         checkpoint: Option<u64>,
     ) -> Result<()>;
+    /// Returns the item identity used for ordering and deduplication.
+    fn item_position(item: &Self::Item) -> &Self::ItemPosition;
     /// Extracts `(has_item, watermark, query_end)` metadata from a list response frame.
     fn extract_metadata(
         response: &Self::ListResponse,
     ) -> (bool, Option<&Watermark>, Option<&QueryEnd>);
+    /// Splits payload from progress and validates projected identity fields.
+    fn split_list(response: Self::ListResponse) -> Result<ListResponseParts<Self>>;
+    /// Whether successful live frames must contain a payload item.
+    fn item_required(_request: &Self::SubscribeRequest) -> bool {
+        false
+    }
+    /// Validates and converts a Subscribe response to a normalized live frame.
+    fn parse_live(
+        response: Self::SubscribeResponse,
+        item_required: bool,
+    ) -> Result<LiveFrame<Self::Item, Progress<Self::Cursor>>>;
+    /// Converts an optional payload and committed progress to a public frame.
+    fn into_output(item: Option<Self::Item>, progress: Progress<Self::Cursor>) -> Self::Output;
     fn dispatch_list(
         client: Client,
         request: Request<Self::ListRequest>,
     ) -> RpcFuture<Self::ListResponse>;
+    fn dispatch_subscribe(
+        client: Client,
+        request: Request<Self::SubscribeRequest>,
+    ) -> RpcFuture<Self::SubscribeResponse>;
 }
+
+fn parse_opaque_live_frame<I, P>(
+    item: Option<PositionedItem<I, P>>,
+    watermark: Option<Watermark>,
+) -> Result<LiveFrame<PositionedItem<I, P>, Progress<Bytes>>> {
+    let watermark = watermark
+        .ok_or_else(|| Status::data_loss("subscription frame is missing its watermark"))?;
+    let cursor = watermark
+        .cursor
+        .ok_or_else(|| Status::data_loss("subscription watermark is missing its cursor"))?;
+    Ok(LiveFrame {
+        item,
+        progress: Progress {
+            cursor,
+            checkpoint: watermark.checkpoint,
+        },
+    })
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ListScanDirection {
     Ascending,

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/mod.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/mod.rs
@@ -1,0 +1,109 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use prost::bytes::Bytes;
+use tonic::Request;
+use tonic::Status;
+use tonic::codegen::BoxStream;
+
+use super::super::Client;
+use super::super::Result;
+use super::observability::LedgerStreamFamily;
+use crate::proto::sui::rpc::v2::Ordering;
+use crate::proto::sui::rpc::v2::QueryEnd;
+use crate::proto::sui::rpc::v2::QueryOptions;
+use crate::proto::sui::rpc::v2::Watermark;
+
+mod checkpoint;
+mod event;
+mod progress;
+mod transaction;
+
+pub(super) use checkpoint::CheckpointAdapter;
+pub(super) use event::EventAdapter;
+pub(super) use progress::CursorDomain;
+pub(super) use progress::Progress;
+pub(super) use transaction::TransactionAdapter;
+pub(super) type RpcFuture<T> = Pin<Box<dyn Future<Output = Result<BoxStream<T>>> + Send + 'static>>;
+
+/// Connects one checkpoint, transaction, or event protocol family to the shared driver.
+pub(super) trait SubscriptionAdapter: Send + Sync + 'static {
+    const FAMILY: LedgerStreamFamily;
+    type Cursor: CursorDomain;
+    type ListRequest: Clone + Send + Sync + 'static;
+    type ListResponse: Send + 'static;
+
+    /// Returns the List request's pagination and ordering options when present.
+    fn options(request: &Self::ListRequest) -> Option<&QueryOptions>;
+    /// Returns mutable List pagination and ordering options, inserting defaults when absent.
+    fn options_mut(request: &mut Self::ListRequest) -> &mut QueryOptions;
+    /// Returns the List request's inclusive lower checkpoint bound.
+    fn start_checkpoint(request: &Self::ListRequest) -> Option<u64>;
+    /// Returns the List request's exclusive upper checkpoint bound.
+    fn end_checkpoint(request: &Self::ListRequest) -> Option<u64>;
+    /// Validates a `CheckpointBound` ending against the request bounds.
+    fn validate_checkpoint_bound(
+        request: &Self::ListRequest,
+        direction: ListScanDirection,
+        checkpoint: Option<u64>,
+    ) -> Result<()>;
+    /// Extracts `(has_item, watermark, query_end)` metadata from a list response frame.
+    fn extract_metadata(
+        response: &Self::ListResponse,
+    ) -> (bool, Option<&Watermark>, Option<&QueryEnd>);
+    fn dispatch_list(
+        client: Client,
+        request: Request<Self::ListRequest>,
+    ) -> RpcFuture<Self::ListResponse>;
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ListScanDirection {
+    Ascending,
+    Descending,
+}
+
+impl ListScanDirection {
+    pub(super) fn from_request<A: SubscriptionAdapter>(request: &A::ListRequest) -> Result<Self> {
+        match A::options(request).and_then(|options| options.ordering) {
+            None => Ok(Self::Ascending),
+            Some(ordering) => match Ordering::try_from(ordering) {
+                Ok(Ordering::Ascending) => Ok(Self::Ascending),
+                Ok(Ordering::Descending) => Ok(Self::Descending),
+                Err(_) => Err(Status::invalid_argument("List ordering is unknown")),
+            },
+        }
+    }
+
+    pub(super) fn resume_bound(self, options: &QueryOptions) -> &Option<Bytes> {
+        match self {
+            Self::Ascending => &options.after,
+            Self::Descending => &options.before,
+        }
+    }
+
+    pub(super) fn set_resume_bound(self, options: &mut QueryOptions, cursor: Bytes) {
+        match self {
+            Self::Ascending => options.after = Some(cursor),
+            Self::Descending => options.before = Some(cursor),
+        }
+    }
+}
+
+pub(super) fn validate_typed_checkpoint_bound(
+    start_checkpoint: Option<u64>,
+    end_checkpoint: Option<u64>,
+    direction: ListScanDirection,
+    watermark_checkpoint: Option<u64>,
+) -> Result<()> {
+    let expected_checkpoint = match direction {
+        ListScanDirection::Ascending => end_checkpoint.and_then(|end| end.checked_sub(1)),
+        ListScanDirection::Descending => Some(start_checkpoint.unwrap_or(0)),
+    };
+    if watermark_checkpoint.is_some() && watermark_checkpoint != expected_checkpoint {
+        Err(Status::data_loss(
+            "List CheckpointBound watermark does not match the requested bound",
+        ))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/progress.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/progress.rs
@@ -1,0 +1,79 @@
+use prost::bytes::Bytes;
+use tonic::Status;
+
+use super::super::super::Result;
+use super::ListScanDirection;
+
+/// A resumable cursor plus known checkpoint coverage.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::client::ledger_streams) struct Progress<C> {
+    pub(in crate::client::ledger_streams) cursor: C,
+    /// Always equals a dense checkpoint cursor; present for opaque cursors when reported.
+    pub(in crate::client::ledger_streams) checkpoint: Option<u64>,
+}
+
+/// Cursor-specific coverage and replay behavior.
+///
+/// Dense checkpoint cursors provide their own coverage and replay whole checkpoints. Opaque
+/// transaction and event cursors rely on reported coverage and replay strictly after the token.
+pub(in crate::client::ledger_streams) trait CursorDomain:
+    Clone + Eq + Send + 'static
+{
+    /// The resumable position a watermark names, or `None` if it does not name one yet.
+    fn position(cursor: &Bytes, checkpoint: Option<u64>) -> Option<Progress<Self>>;
+}
+
+impl<C: CursorDomain> Progress<C> {
+    pub(in crate::client::ledger_streams) fn inherit_checkpoint_coverage(
+        &mut self,
+        previous: &Self,
+    ) {
+        if self.checkpoint.is_none() {
+            self.checkpoint = previous.checkpoint;
+        }
+    }
+
+    pub(in crate::client::ledger_streams) fn validate_list_successor(
+        &self,
+        next: &Self,
+        direction: ListScanDirection,
+    ) -> Result<()> {
+        let current_checkpoint = self.checkpoint;
+        let next_checkpoint = next.checkpoint;
+        if matches!((current_checkpoint, next_checkpoint), (Some(_), None)) {
+            return Err(Status::data_loss(
+                "List checkpoint coverage became unavailable",
+            ));
+        }
+        let regressed = match (current_checkpoint, next_checkpoint) {
+            (Some(current), Some(next)) => match direction {
+                ListScanDirection::Ascending => next < current,
+                ListScanDirection::Descending => next > current,
+            },
+            _ => false,
+        };
+        if regressed {
+            Err(Status::data_loss("List checkpoint coverage regressed"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl CursorDomain for u64 {
+    fn position(_cursor: &Bytes, checkpoint: Option<u64>) -> Option<Progress<Self>> {
+        checkpoint.map(|checkpoint| Progress {
+            cursor: checkpoint,
+            checkpoint: Some(checkpoint),
+        })
+    }
+}
+
+impl CursorDomain for Bytes {
+    fn position(cursor: &Bytes, checkpoint: Option<u64>) -> Option<Progress<Self>> {
+        Some(Progress {
+            cursor: cursor.clone(),
+            checkpoint,
+        })
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/progress.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/progress.rs
@@ -2,6 +2,7 @@ use prost::bytes::Bytes;
 use tonic::Status;
 
 use super::super::super::Result;
+use super::CHECKPOINT_CURSOR_OVERFLOW;
 use super::ListScanDirection;
 
 /// A resumable cursor plus known checkpoint coverage.
@@ -21,15 +22,107 @@ pub(in crate::client::ledger_streams) trait CursorDomain:
 {
     /// The resumable position a watermark names, or `None` if it does not name one yet.
     fn position(cursor: &Bytes, checkpoint: Option<u64>) -> Option<Progress<Self>>;
+
+    /// Builds the replay interval strictly after this committed cursor and ending at `upper`.
+    fn gap(&self, committed_checkpoint: u64, upper: GapUpper<'_, Self>) -> Result<RecoveryGap>;
+}
+
+pub(in crate::client::ledger_streams) enum GapUpper<'a, C> {
+    Cursor(&'a C, u64),
+    EndOfCheckpoint(u64),
+}
+
+/// Recovery selected by comparing a subscription's first frame with committed progress.
+pub(in crate::client::ledger_streams) enum Recovery {
+    /// Deliver immediately from the committed position.
+    Live,
+    /// Replay the missing interval while buffering live frames.
+    Replay(RecoveryGap),
+    /// Hide frames until the subscription reaches committed progress.
+    MuteUntilCommitted,
+}
+
+/// Historical List interval between subscription positions.
+pub(in crate::client::ledger_streams) enum RecoveryGap {
+    /// Inclusive start and exclusive end typed range. The replay re-delivers its boundary item.
+    Checkpoints {
+        start_checkpoint: u64,
+        end_checkpoint: u64,
+    },
+    /// Strictly after `after`, ending before a cursor or after an inclusive checkpoint.
+    Cursors { after: Bytes, upper: CursorGapUpper },
+}
+
+pub(in crate::client::ledger_streams) enum CursorGapUpper {
+    Before(Bytes),
+    EndOfCheckpoint(u64),
+}
+
+impl RecoveryGap {
+    pub(in crate::client::ledger_streams) fn replays_boundary_item(&self) -> bool {
+        matches!(self, Self::Checkpoints { .. })
+    }
+}
+
+/// Advancement between ordered frames from one subscription.
+///
+/// Same-cursor coverage growth advances knowledge; only identical progress is a duplicate.
+pub(in crate::client::ledger_streams) enum ProgressAdvance {
+    Unchanged,
+    CheckpointCoverageAdvanced,
+    CursorAdvanced,
 }
 
 impl<C: CursorDomain> Progress<C> {
+    pub(in crate::client::ledger_streams) fn has_checkpoint_coverage(&self) -> bool {
+        self.checkpoint.is_some()
+    }
+
+    pub(in crate::client::ledger_streams) fn same_position(&self, other: &Self) -> bool {
+        self.cursor == other.cursor
+    }
+
     pub(in crate::client::ledger_streams) fn inherit_checkpoint_coverage(
         &mut self,
         previous: &Self,
     ) {
         if self.checkpoint.is_none() {
             self.checkpoint = previous.checkpoint;
+        }
+    }
+
+    pub(in crate::client::ledger_streams) fn classify_consecutive_subscription_progress(
+        &self,
+        next: &Self,
+        item_present: bool,
+    ) -> Result<ProgressAdvance> {
+        let current_checkpoint = self.checkpoint;
+        let next_checkpoint = next.checkpoint;
+        if matches!((current_checkpoint, next_checkpoint), (Some(_), None)) {
+            Err(Status::data_loss(
+                "subscription checkpoint coverage became unavailable",
+            ))
+        } else if matches!(
+            (current_checkpoint, next_checkpoint),
+            (Some(current), Some(next)) if next < current
+        ) {
+            Err(Status::data_loss(
+                "subscription checkpoint coverage regressed",
+            ))
+        } else if self.same_position(next) && item_present {
+            Err(Status::data_loss("subscription item repeated its cursor"))
+        } else if !self.same_position(next) {
+            // Frames from one subscription stream are already in ledger order. Checkpoint
+            // coverage is needed only to compare frames from different subscriptions.
+            Ok(ProgressAdvance::CursorAdvanced)
+        } else if matches!(
+            (current_checkpoint, next_checkpoint),
+            (Some(current), Some(next)) if next > current
+        ) || matches!((current_checkpoint, next_checkpoint), (None, Some(_)))
+        {
+            Ok(ProgressAdvance::CheckpointCoverageAdvanced)
+        } else {
+            Ok(ProgressAdvance::Unchanged)
         }
     }
 
@@ -58,6 +151,40 @@ impl<C: CursorDomain> Progress<C> {
             Ok(())
         }
     }
+
+    pub(in crate::client::ledger_streams) fn plan_recovery(
+        &self,
+        new: &Self,
+        known_coverage: Option<u64>,
+    ) -> Result<Recovery> {
+        let committed = self.checkpoint.max(known_coverage);
+        if self.same_position(new) {
+            return if matches!(
+                (committed, new.checkpoint),
+                (Some(committed), Some(new_checkpoint)) if new_checkpoint < committed
+            ) {
+                Ok(Recovery::MuteUntilCommitted)
+            } else {
+                Ok(Recovery::Live)
+            };
+        }
+        match (committed, new.checkpoint) {
+            (Some(committed), Some(new_checkpoint)) if new_checkpoint < committed => {
+                Ok(Recovery::MuteUntilCommitted)
+            }
+            (Some(committed), Some(new_checkpoint)) if new_checkpoint > committed => {
+                Ok(Recovery::Replay(self.cursor.gap(
+                    committed,
+                    GapUpper::Cursor(&new.cursor, new_checkpoint),
+                )?))
+            }
+            (Some(committed), Some(_)) => Ok(Recovery::Replay(
+                self.cursor
+                    .gap(committed, GapUpper::EndOfCheckpoint(committed))?,
+            )),
+            _ => Ok(Recovery::MuteUntilCommitted),
+        }
+    }
 }
 
 impl CursorDomain for u64 {
@@ -67,6 +194,22 @@ impl CursorDomain for u64 {
             checkpoint: Some(checkpoint),
         })
     }
+
+    fn gap(&self, committed_checkpoint: u64, upper: GapUpper<'_, Self>) -> Result<RecoveryGap> {
+        let upper_checkpoint = match upper {
+            GapUpper::Cursor(_, checkpoint) | GapUpper::EndOfCheckpoint(checkpoint) => checkpoint,
+        };
+        let start_checkpoint = committed_checkpoint
+            .checked_add(1)
+            .ok_or_else(|| Status::out_of_range(CHECKPOINT_CURSOR_OVERFLOW))?;
+        let end_checkpoint = upper_checkpoint
+            .checked_add(1)
+            .ok_or_else(|| Status::out_of_range(CHECKPOINT_CURSOR_OVERFLOW))?;
+        Ok(RecoveryGap::Checkpoints {
+            start_checkpoint,
+            end_checkpoint,
+        })
+    }
 }
 
 impl CursorDomain for Bytes {
@@ -74,6 +217,17 @@ impl CursorDomain for Bytes {
         Some(Progress {
             cursor: cursor.clone(),
             checkpoint,
+        })
+    }
+
+    fn gap(&self, _committed_checkpoint: u64, upper: GapUpper<'_, Self>) -> Result<RecoveryGap> {
+        let upper = match upper {
+            GapUpper::Cursor(cursor, _) => CursorGapUpper::Before(cursor.clone()),
+            GapUpper::EndOfCheckpoint(checkpoint) => CursorGapUpper::EndOfCheckpoint(checkpoint),
+        };
+        Ok(RecoveryGap::Cursors {
+            after: self.clone(),
+            upper,
         })
     }
 }

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/transaction.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/transaction.rs
@@ -1,0 +1,71 @@
+use prost::bytes::Bytes;
+use tonic::Request;
+use tonic::codegen::BoxStream;
+
+use super::super::super::Client;
+use super::super::super::Result;
+use super::super::observability::LedgerStreamFamily;
+use super::ListScanDirection;
+use super::RpcFuture;
+use super::SubscriptionAdapter;
+use crate::proto::sui::rpc::v2::ListTransactionsRequest;
+use crate::proto::sui::rpc::v2::ListTransactionsResponse;
+use crate::proto::sui::rpc::v2::QueryEnd;
+use crate::proto::sui::rpc::v2::QueryOptions;
+use crate::proto::sui::rpc::v2::Watermark;
+
+pub(in crate::client::ledger_streams) struct TransactionAdapter;
+
+impl SubscriptionAdapter for TransactionAdapter {
+    const FAMILY: LedgerStreamFamily = LedgerStreamFamily::Transaction;
+
+    type Cursor = Bytes;
+    type ListRequest = ListTransactionsRequest;
+    type ListResponse = ListTransactionsResponse;
+    fn options(request: &Self::ListRequest) -> Option<&QueryOptions> {
+        request.options.as_ref()
+    }
+
+    fn options_mut(request: &mut Self::ListRequest) -> &mut QueryOptions {
+        request.options.get_or_insert_with(QueryOptions::default)
+    }
+
+    fn start_checkpoint(request: &Self::ListRequest) -> Option<u64> {
+        request.start_checkpoint
+    }
+
+    fn end_checkpoint(request: &Self::ListRequest) -> Option<u64> {
+        request.end_checkpoint
+    }
+    fn validate_checkpoint_bound(
+        _request: &Self::ListRequest,
+        _direction: ListScanDirection,
+        _checkpoint: Option<u64>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn extract_metadata(
+        response: &Self::ListResponse,
+    ) -> (bool, Option<&Watermark>, Option<&QueryEnd>) {
+        (
+            response.transaction.is_some(),
+            response.watermark.as_ref(),
+            response.end.as_ref(),
+        )
+    }
+
+    fn dispatch_list(
+        mut client: Client,
+        request: Request<Self::ListRequest>,
+    ) -> RpcFuture<Self::ListResponse> {
+        Box::pin(async move {
+            let stream = client
+                .ledger_client()
+                .list_transactions(request)
+                .await?
+                .into_inner();
+            Ok(Box::pin(stream) as BoxStream<Self::ListResponse>)
+        })
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/adapter/transaction.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/adapter/transaction.rs
@@ -1,27 +1,60 @@
 use prost::bytes::Bytes;
 use tonic::Request;
+use tonic::Status;
 use tonic::codegen::BoxStream;
 
 use super::super::super::Client;
 use super::super::super::Result;
 use super::super::observability::LedgerStreamFamily;
+use super::super::types::TransactionStreamFrame;
+use super::ListResponseParts;
 use super::ListScanDirection;
+use super::LiveFrame;
+use super::PositionedItem;
+use super::Progress;
 use super::RpcFuture;
 use super::SubscriptionAdapter;
+use super::parse_opaque_live_frame;
+use crate::proto::sui::rpc::v2::ExecutedTransaction;
 use crate::proto::sui::rpc::v2::ListTransactionsRequest;
 use crate::proto::sui::rpc::v2::ListTransactionsResponse;
 use crate::proto::sui::rpc::v2::QueryEnd;
 use crate::proto::sui::rpc::v2::QueryOptions;
+use crate::proto::sui::rpc::v2::SubscribeTransactionsRequest;
+use crate::proto::sui::rpc::v2::SubscribeTransactionsResponse;
 use crate::proto::sui::rpc::v2::Watermark;
 
 pub(in crate::client::ledger_streams) struct TransactionAdapter;
 
 impl SubscriptionAdapter for TransactionAdapter {
     const FAMILY: LedgerStreamFamily = LedgerStreamFamily::Transaction;
+    const REQUIRED_READ_MASK_FIELDS: &'static [&'static str] = &["checkpoint", "transaction_index"];
+    const READ_MASK_REQUIREMENT: &'static str =
+        "read_mask must include \"checkpoint\" and \"transaction_index\" or \"*\"";
 
+    type Item = PositionedItem<ExecutedTransaction, (u64, u64)>;
+    type ItemPosition = (u64, u64);
     type Cursor = Bytes;
+    type Output = TransactionStreamFrame;
     type ListRequest = ListTransactionsRequest;
     type ListResponse = ListTransactionsResponse;
+    type SubscribeRequest = SubscribeTransactionsRequest;
+    type SubscribeResponse = SubscribeTransactionsResponse;
+
+    fn list_read_mask(request: &Self::ListRequest) -> Option<&prost_types::FieldMask> {
+        request.read_mask.as_ref()
+    }
+
+    fn list_request_from_subscribe(request: &Self::SubscribeRequest) -> Self::ListRequest {
+        ListTransactionsRequest {
+            read_mask: request.read_mask.clone(),
+            filter: request.filter.clone(),
+            start_checkpoint: None,
+            end_checkpoint: None,
+            options: None,
+        }
+    }
+
     fn options(request: &Self::ListRequest) -> Option<&QueryOptions> {
         request.options.as_ref()
     }
@@ -34,8 +67,35 @@ impl SubscriptionAdapter for TransactionAdapter {
         request.start_checkpoint
     }
 
+    fn set_start_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>) {
+        request.start_checkpoint = checkpoint;
+    }
+
     fn end_checkpoint(request: &Self::ListRequest) -> Option<u64> {
         request.end_checkpoint
+    }
+
+    fn set_end_checkpoint(request: &mut Self::ListRequest, checkpoint: Option<u64>) {
+        request.end_checkpoint = checkpoint;
+    }
+
+    fn set_ascending_resume(
+        request: &mut Self::ListRequest,
+        progress: &Progress<Self::Cursor>,
+    ) -> Result<()> {
+        Self::options_mut(request).after = Some(progress.cursor.clone());
+        Ok(())
+    }
+
+    fn request_resume_position(request: &Self::ListRequest) -> Option<Progress<Self::Cursor>> {
+        request
+            .options
+            .as_ref()
+            .and_then(|options| options.after.clone())
+            .map(|cursor| Progress {
+                cursor,
+                checkpoint: None,
+            })
     }
     fn validate_checkpoint_bound(
         _request: &Self::ListRequest,
@@ -43,6 +103,9 @@ impl SubscriptionAdapter for TransactionAdapter {
         _checkpoint: Option<u64>,
     ) -> Result<()> {
         Ok(())
+    }
+    fn item_position(item: &Self::Item) -> &Self::ItemPosition {
+        item.position()
     }
 
     fn extract_metadata(
@@ -53,6 +116,31 @@ impl SubscriptionAdapter for TransactionAdapter {
             response.watermark.as_ref(),
             response.end.as_ref(),
         )
+    }
+
+    fn split_list(response: Self::ListResponse) -> Result<ListResponseParts<Self>> {
+        let item = response.transaction.map(position_transaction).transpose()?;
+        Ok(ListResponseParts {
+            item,
+            watermark: response.watermark,
+        })
+    }
+
+    fn parse_live(
+        response: Self::SubscribeResponse,
+        _item_required: bool,
+    ) -> Result<LiveFrame<Self::Item, Progress<Self::Cursor>>> {
+        let item = response.transaction.map(position_transaction).transpose()?;
+        parse_opaque_live_frame(item, response.watermark)
+    }
+
+    fn into_output(item: Option<Self::Item>, progress: Progress<Self::Cursor>) -> Self::Output {
+        let transaction = item.map(PositionedItem::into_payload);
+        TransactionStreamFrame {
+            transaction,
+            cursor: progress.cursor,
+            covered_checkpoint: progress.checkpoint,
+        }
     }
 
     fn dispatch_list(
@@ -68,4 +156,33 @@ impl SubscriptionAdapter for TransactionAdapter {
             Ok(Box::pin(stream) as BoxStream<Self::ListResponse>)
         })
     }
+
+    fn dispatch_subscribe(
+        mut client: Client,
+        request: Request<Self::SubscribeRequest>,
+    ) -> RpcFuture<Self::SubscribeResponse> {
+        Box::pin(async move {
+            let stream = client
+                .subscription_client()
+                .subscribe_transactions(request)
+                .await?
+                .into_inner();
+            Ok(Box::pin(stream) as BoxStream<Self::SubscribeResponse>)
+        })
+    }
+}
+
+fn position_transaction(
+    transaction: ExecutedTransaction,
+) -> Result<PositionedItem<ExecutedTransaction, (u64, u64)>> {
+    let checkpoint = transaction
+        .checkpoint
+        .ok_or_else(|| Status::data_loss("transaction item is missing its checkpoint"))?;
+    let transaction_index = transaction
+        .transaction_index
+        .ok_or_else(|| Status::data_loss("transaction item is missing its transaction index"))?;
+    Ok(PositionedItem::new(
+        transaction,
+        (checkpoint, transaction_index),
+    ))
 }

--- a/crates/sui-rpc/src/client/ledger_streams/facade.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/facade.rs
@@ -7,20 +7,28 @@ use super::adapter::EventAdapter;
 use super::adapter::SubscriptionAdapter;
 use super::adapter::TransactionAdapter;
 use super::list::ListDriver;
+use super::stream::Driver;
+use super::stream::Start;
 use super::types::CheckpointStreamFrame;
 use super::types::CheckpointStreamRequest;
+use super::types::CheckpointStreamStart;
 use super::types::EventStreamFrame;
 use super::types::EventStreamRequest;
+use super::types::EventStreamStart;
 use super::types::LedgerStreamConfig;
 use super::types::ListConfig;
 use super::types::TransactionStreamFrame;
 use super::types::TransactionStreamRequest;
+use super::types::TransactionStreamStart;
 use crate::proto::sui::rpc::v2::ListCheckpointsRequest;
 use crate::proto::sui::rpc::v2::ListCheckpointsResponse;
 use crate::proto::sui::rpc::v2::ListEventsRequest;
 use crate::proto::sui::rpc::v2::ListEventsResponse;
 use crate::proto::sui::rpc::v2::ListTransactionsRequest;
 use crate::proto::sui::rpc::v2::ListTransactionsResponse;
+use crate::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
+use crate::proto::sui::rpc::v2::SubscribeEventsRequest;
+use crate::proto::sui::rpc::v2::SubscribeTransactionsRequest;
 
 impl Client {
     /// Paginates `ListCheckpoints` requests into a stream of raw response pages.
@@ -65,8 +73,29 @@ impl Client {
         request: CheckpointStreamRequest,
         config: LedgerStreamConfig,
     ) -> impl Stream<Item = Result<CheckpointStreamFrame>> + Send + 'static {
-        let _ = (request, config);
-        unimplemented_stream()
+        let subscribe_payload = SubscribeCheckpointsRequest {
+            read_mask: request.read_mask.clone(),
+            filter: request.filter.clone(),
+        };
+        let list_template = ListCheckpointsRequest {
+            read_mask: request.read_mask,
+            filter: request.filter,
+            start_checkpoint: None,
+            end_checkpoint: None,
+            options: None,
+        };
+        let start = match request.start {
+            CheckpointStreamStart::Tip => Start::Tip,
+            CheckpointStreamStart::Checkpoint(checkpoint) => Start::Checkpoint(checkpoint),
+        };
+        resumable_stream(Driver::<CheckpointAdapter>::new_stream(
+            self.clone(),
+            subscribe_payload,
+            list_template,
+            start,
+            request.delivery,
+            config,
+        ))
     }
 
     /// Paginates `ListTransactions` requests into a stream of raw response pages.
@@ -111,8 +140,30 @@ impl Client {
         request: TransactionStreamRequest,
         config: LedgerStreamConfig,
     ) -> impl Stream<Item = Result<TransactionStreamFrame>> + Send + 'static {
-        let _ = (request, config);
-        unimplemented_stream()
+        let subscribe_payload = SubscribeTransactionsRequest {
+            read_mask: request.read_mask.clone(),
+            filter: request.filter.clone(),
+        };
+        let list_template = ListTransactionsRequest {
+            read_mask: request.read_mask,
+            filter: request.filter,
+            start_checkpoint: None,
+            end_checkpoint: None,
+            options: None,
+        };
+        let start = match request.start {
+            TransactionStreamStart::Tip => Start::Tip,
+            TransactionStreamStart::Checkpoint(checkpoint) => Start::Checkpoint(checkpoint),
+            TransactionStreamStart::Resume(cursor) => Start::After(cursor),
+        };
+        resumable_stream(Driver::<TransactionAdapter>::new_stream(
+            self.clone(),
+            subscribe_payload,
+            list_template,
+            start,
+            request.delivery,
+            config,
+        ))
     }
 
     /// Paginates `ListEvents` requests into a stream of raw response pages.
@@ -158,8 +209,30 @@ impl Client {
         request: EventStreamRequest,
         config: LedgerStreamConfig,
     ) -> impl Stream<Item = Result<EventStreamFrame>> + Send + 'static {
-        let _ = (request, config);
-        unimplemented_stream()
+        let subscribe_payload = SubscribeEventsRequest {
+            read_mask: request.read_mask.clone(),
+            filter: request.filter.clone(),
+        };
+        let list_template = ListEventsRequest {
+            read_mask: request.read_mask,
+            filter: request.filter,
+            start_checkpoint: None,
+            end_checkpoint: None,
+            options: None,
+        };
+        let start = match request.start {
+            EventStreamStart::Tip => Start::Tip,
+            EventStreamStart::Checkpoint(checkpoint) => Start::Checkpoint(checkpoint),
+            EventStreamStart::Resume(cursor) => Start::After(cursor),
+        };
+        resumable_stream(Driver::<EventAdapter>::new_stream(
+            self.clone(),
+            subscribe_payload,
+            list_template,
+            start,
+            request.delivery,
+            config,
+        ))
     }
 }
 
@@ -171,6 +244,10 @@ fn list_stream<A: SubscriptionAdapter>(
     })
 }
 
-fn unimplemented_stream<T>() -> futures::stream::Empty<Result<T>> {
-    unimplemented!()
+fn resumable_stream<A: SubscriptionAdapter>(
+    driver: Driver<A>,
+) -> impl Stream<Item = Result<A::Output>> + Send + 'static {
+    futures::stream::unfold(driver, |mut driver| async move {
+        driver.next().await.map(|item| (item, driver))
+    })
 }

--- a/crates/sui-rpc/src/client/ledger_streams/facade.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/facade.rs
@@ -2,6 +2,11 @@ use futures::Stream;
 
 use super::super::Client;
 use super::super::Result;
+use super::adapter::CheckpointAdapter;
+use super::adapter::EventAdapter;
+use super::adapter::SubscriptionAdapter;
+use super::adapter::TransactionAdapter;
+use super::list::ListDriver;
 use super::types::CheckpointStreamFrame;
 use super::types::CheckpointStreamRequest;
 use super::types::EventStreamFrame;
@@ -34,8 +39,11 @@ impl Client {
         request: ListCheckpointsRequest,
         config: ListConfig,
     ) -> impl Stream<Item = Result<ListCheckpointsResponse>> + Send + 'static {
-        let _ = (request, config);
-        unimplemented_stream()
+        list_stream(ListDriver::<CheckpointAdapter>::new(
+            self.clone(),
+            request,
+            config.into_stream_config(),
+        ))
     }
 
     /// Streams checkpoints indefinitely, automatically retrying transient errors.
@@ -77,8 +85,11 @@ impl Client {
         request: ListTransactionsRequest,
         config: ListConfig,
     ) -> impl Stream<Item = Result<ListTransactionsResponse>> + Send + 'static {
-        let _ = (request, config);
-        unimplemented_stream()
+        list_stream(ListDriver::<TransactionAdapter>::new(
+            self.clone(),
+            request,
+            config.into_stream_config(),
+        ))
     }
 
     /// Streams transactions indefinitely, automatically retrying transient errors.
@@ -120,8 +131,11 @@ impl Client {
         request: ListEventsRequest,
         config: ListConfig,
     ) -> impl Stream<Item = Result<ListEventsResponse>> + Send + 'static {
-        let _ = (request, config);
-        unimplemented_stream()
+        list_stream(ListDriver::<EventAdapter>::new(
+            self.clone(),
+            request,
+            config.into_stream_config(),
+        ))
     }
 
     /// Streams events indefinitely, automatically retrying transient errors.
@@ -147,6 +161,14 @@ impl Client {
         let _ = (request, config);
         unimplemented_stream()
     }
+}
+
+fn list_stream<A: SubscriptionAdapter>(
+    driver: ListDriver<A>,
+) -> impl Stream<Item = Result<A::ListResponse>> + Send + 'static {
+    futures::stream::unfold(driver, |mut driver| async move {
+        driver.next().await.map(|item| (item, driver))
+    })
 }
 
 fn unimplemented_stream<T>() -> futures::stream::Empty<Result<T>> {

--- a/crates/sui-rpc/src/client/ledger_streams/facade.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/facade.rs
@@ -1,0 +1,154 @@
+use futures::Stream;
+
+use super::super::Client;
+use super::super::Result;
+use super::types::CheckpointStreamFrame;
+use super::types::CheckpointStreamRequest;
+use super::types::EventStreamFrame;
+use super::types::EventStreamRequest;
+use super::types::LedgerStreamConfig;
+use super::types::ListConfig;
+use super::types::TransactionStreamFrame;
+use super::types::TransactionStreamRequest;
+use crate::proto::sui::rpc::v2::ListCheckpointsRequest;
+use crate::proto::sui::rpc::v2::ListCheckpointsResponse;
+use crate::proto::sui::rpc::v2::ListEventsRequest;
+use crate::proto::sui::rpc::v2::ListEventsResponse;
+use crate::proto::sui::rpc::v2::ListTransactionsRequest;
+use crate::proto::sui::rpc::v2::ListTransactionsResponse;
+
+impl Client {
+    /// Paginates `ListCheckpoints` requests into a stream of raw response pages.
+    ///
+    /// Automatically follows `ItemLimit` and `ScanLimit` pagination until reaching the
+    /// request's end bound or the ledger tip.
+    pub fn list_checkpoints(
+        &self,
+        request: ListCheckpointsRequest,
+    ) -> impl Stream<Item = Result<ListCheckpointsResponse>> + Send + 'static {
+        self.list_checkpoints_with_config(request, ListConfig::default())
+    }
+    /// Performs [`Client::list_checkpoints`] using `config`.
+    pub fn list_checkpoints_with_config(
+        &self,
+        request: ListCheckpointsRequest,
+        config: ListConfig,
+    ) -> impl Stream<Item = Result<ListCheckpointsResponse>> + Send + 'static {
+        let _ = (request, config);
+        unimplemented_stream()
+    }
+
+    /// Streams checkpoints indefinitely, automatically retrying transient errors.
+    ///
+    /// The request's read mask must include `sequence_number` (or `*`). To resume after a
+    /// previous checkpoint, pass `cursor + 1` to [`CheckpointStreamStart::Checkpoint`].
+    ///
+    /// For a finite read that stops at a bound, use [`Client::list_checkpoints`].
+    pub fn stream_checkpoints(
+        &self,
+        request: CheckpointStreamRequest,
+    ) -> impl Stream<Item = Result<CheckpointStreamFrame>> + Send + 'static {
+        self.stream_checkpoints_with_config(request, LedgerStreamConfig::default())
+    }
+
+    /// Performs [`Client::stream_checkpoints`] using `config`.
+    pub fn stream_checkpoints_with_config(
+        &self,
+        request: CheckpointStreamRequest,
+        config: LedgerStreamConfig,
+    ) -> impl Stream<Item = Result<CheckpointStreamFrame>> + Send + 'static {
+        let _ = (request, config);
+        unimplemented_stream()
+    }
+
+    /// Paginates `ListTransactions` requests into a stream of raw response pages.
+    ///
+    /// Automatically follows `ItemLimit` and `ScanLimit` pagination until reaching the
+    /// request's end bound or the ledger tip.
+    pub fn list_transactions(
+        &self,
+        request: ListTransactionsRequest,
+    ) -> impl Stream<Item = Result<ListTransactionsResponse>> + Send + 'static {
+        self.list_transactions_with_config(request, ListConfig::default())
+    }
+    /// Performs [`Client::list_transactions`] using `config`.
+    pub fn list_transactions_with_config(
+        &self,
+        request: ListTransactionsRequest,
+        config: ListConfig,
+    ) -> impl Stream<Item = Result<ListTransactionsResponse>> + Send + 'static {
+        let _ = (request, config);
+        unimplemented_stream()
+    }
+
+    /// Streams transactions indefinitely, automatically retrying transient errors.
+    ///
+    /// The request's read mask must include `checkpoint` and `transaction_index` (or `*`).
+    /// To resume from a previous frame, pass `frame.cursor` to [`TransactionStreamStart::Resume`].
+    ///
+    /// For a finite read that stops at a bound, use [`Client::list_transactions`].
+    pub fn stream_transactions(
+        &self,
+        request: TransactionStreamRequest,
+    ) -> impl Stream<Item = Result<TransactionStreamFrame>> + Send + 'static {
+        self.stream_transactions_with_config(request, LedgerStreamConfig::default())
+    }
+
+    /// Performs [`Client::stream_transactions`] using `config`.
+    pub fn stream_transactions_with_config(
+        &self,
+        request: TransactionStreamRequest,
+        config: LedgerStreamConfig,
+    ) -> impl Stream<Item = Result<TransactionStreamFrame>> + Send + 'static {
+        let _ = (request, config);
+        unimplemented_stream()
+    }
+
+    /// Paginates `ListEvents` requests into a stream of raw response pages.
+    ///
+    /// Automatically follows `ItemLimit` and `ScanLimit` pagination until reaching the
+    /// request's end bound or the ledger tip.
+    pub fn list_events(
+        &self,
+        request: ListEventsRequest,
+    ) -> impl Stream<Item = Result<ListEventsResponse>> + Send + 'static {
+        self.list_events_with_config(request, ListConfig::default())
+    }
+    /// Performs [`Client::list_events`] using `config`.
+    pub fn list_events_with_config(
+        &self,
+        request: ListEventsRequest,
+        config: ListConfig,
+    ) -> impl Stream<Item = Result<ListEventsResponse>> + Send + 'static {
+        let _ = (request, config);
+        unimplemented_stream()
+    }
+
+    /// Streams events indefinitely, automatically retrying transient errors.
+    ///
+    /// The request's read mask must include `checkpoint`, `transaction_index`, and `event_index`
+    /// (or `*`). To resume from a previous frame, pass `frame.cursor` to
+    /// [`EventStreamStart::Resume`].
+    ///
+    /// For a finite read that stops at a bound, use [`Client::list_events`].
+    pub fn stream_events(
+        &self,
+        request: EventStreamRequest,
+    ) -> impl Stream<Item = Result<EventStreamFrame>> + Send + 'static {
+        self.stream_events_with_config(request, LedgerStreamConfig::default())
+    }
+
+    /// Performs [`Client::stream_events`] using `config`.
+    pub fn stream_events_with_config(
+        &self,
+        request: EventStreamRequest,
+        config: LedgerStreamConfig,
+    ) -> impl Stream<Item = Result<EventStreamFrame>> + Send + 'static {
+        let _ = (request, config);
+        unimplemented_stream()
+    }
+}
+
+fn unimplemented_stream<T>() -> futures::stream::Empty<Result<T>> {
+    unimplemented!()
+}

--- a/crates/sui-rpc/src/client/ledger_streams/list.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/list.rs
@@ -1,7 +1,8 @@
-use futures::StreamExt;
-use prost::bytes::Bytes;
 use std::pin::Pin;
 use std::time::Duration;
+
+use futures::StreamExt;
+use prost::bytes::Bytes;
 use tonic::Request;
 use tonic::Status;
 use tonic::codegen::BoxStream;
@@ -9,8 +10,10 @@ use tonic::codegen::BoxStream;
 use super::super::Client;
 use super::super::Result;
 use super::adapter::CursorDomain;
+use super::adapter::CursorGapUpper;
 use super::adapter::ListScanDirection;
 use super::adapter::Progress;
+use super::adapter::RecoveryGap;
 use super::adapter::RpcFuture;
 use super::adapter::SubscriptionAdapter;
 use super::observability::LedgerStreamEvent;
@@ -19,6 +22,7 @@ use super::observability::LedgerStreamOperation;
 use super::observability::LedgerStreamStage;
 use super::retry::FailurePhase;
 use super::retry::RetryState;
+use super::retry::backoff_delay;
 use super::types::LedgerStreamConfig;
 use crate::proto::sui::rpc::v2::QueryEnd;
 use crate::proto::sui::rpc::v2::QueryEndReason;
@@ -32,7 +36,17 @@ pub(super) struct ExpectedEnd {
     checkpoint_without_prior_progress: bool,
     cursor_without_prior_progress: bool,
 }
+
 impl ExpectedEnd {
+    fn from_bounds(checkpoint: bool, cursor: bool) -> Self {
+        Self {
+            checkpoint_after_progress: checkpoint,
+            cursor_after_progress: cursor,
+            checkpoint_without_prior_progress: checkpoint,
+            cursor_without_prior_progress: cursor,
+        }
+    }
+
     fn accepts(
         self,
         reason: QueryEndReason,
@@ -62,6 +76,112 @@ fn validate_query_end_item(reason: QueryEndReason, item_present: bool) -> Result
         ))
     } else {
         Ok(())
+    }
+}
+
+fn to_exclusive_end_bound(checkpoint_height: u64) -> Result<u64> {
+    checkpoint_height.checked_add(1).ok_or_else(|| {
+        Status::out_of_range("checkpoint height cannot be converted to an exclusive end bound")
+    })
+}
+
+/// Sets the page size on an internal request; caller-built `list_*` requests bypass this path.
+fn apply_internal_list_page_limit<A: SubscriptionAdapter>(
+    request: &mut A::ListRequest,
+    list_page_limit: Option<u32>,
+) {
+    A::options_mut(request).limit = list_page_limit;
+}
+
+pub(super) fn build_initial_list_request<A: SubscriptionAdapter>(
+    template: &A::ListRequest,
+    checkpoint_height: u64,
+    list_page_limit: Option<u32>,
+) -> Result<(A::ListRequest, ExpectedEnd)> {
+    let mut request = template.clone();
+    apply_internal_list_page_limit::<A>(&mut request, list_page_limit);
+    A::set_end_checkpoint(
+        &mut request,
+        Some(to_exclusive_end_bound(checkpoint_height)?),
+    );
+    Ok((request, ExpectedEnd::from_bounds(true, false)))
+}
+
+/// Queries a single tip checkpoint to establish baseline watermark progress (used when starting in
+/// Poll mode, or recovering baseline progress after an initial Subscribe connection failure).
+pub(super) fn build_live_tip_baseline_list_request<A: SubscriptionAdapter>(
+    template: &A::ListRequest,
+    checkpoint_height: u64,
+    list_page_limit: Option<u32>,
+) -> Result<(A::ListRequest, ExpectedEnd)> {
+    let mut request = template.clone();
+    apply_internal_list_page_limit::<A>(&mut request, list_page_limit);
+    A::set_start_checkpoint(&mut request, Some(checkpoint_height));
+    A::set_end_checkpoint(
+        &mut request,
+        Some(to_exclusive_end_bound(checkpoint_height)?),
+    );
+    let options = A::options_mut(&mut request);
+    options.after = None;
+    options.before = None;
+    Ok((request, ExpectedEnd::from_bounds(true, false)))
+}
+
+pub(super) fn build_polling_list_request<A: SubscriptionAdapter>(
+    template: &A::ListRequest,
+    committed_progress: &Progress<A::Cursor>,
+    checkpoint_height: u64,
+    list_page_limit: Option<u32>,
+) -> Result<(A::ListRequest, ExpectedEnd)> {
+    let mut request = template.clone();
+    apply_internal_list_page_limit::<A>(&mut request, list_page_limit);
+    A::set_ascending_resume(&mut request, committed_progress)?;
+    A::options_mut(&mut request).before = None;
+    A::set_end_checkpoint(
+        &mut request,
+        Some(to_exclusive_end_bound(checkpoint_height)?),
+    );
+    Ok((request, ExpectedEnd::from_bounds(true, false)))
+}
+
+pub(super) fn build_recovery_list_request<A: SubscriptionAdapter>(
+    template: A::ListRequest,
+    gap: &RecoveryGap,
+    list_page_limit: Option<u32>,
+) -> Result<(A::ListRequest, ExpectedEnd)> {
+    let mut request = template;
+    apply_internal_list_page_limit::<A>(&mut request, list_page_limit);
+    match gap {
+        RecoveryGap::Checkpoints {
+            start_checkpoint,
+            end_checkpoint,
+        } => {
+            A::set_start_checkpoint(&mut request, Some(*start_checkpoint));
+            A::set_end_checkpoint(&mut request, Some(*end_checkpoint));
+            let options = A::options_mut(&mut request);
+            options.after = None;
+            options.before = None;
+            Ok((request, ExpectedEnd::from_bounds(true, false)))
+        }
+        RecoveryGap::Cursors {
+            after,
+            upper: CursorGapUpper::Before(before),
+        } => {
+            let options = A::options_mut(&mut request);
+            options.after = Some(after.clone());
+            options.before = Some(before.clone());
+            Ok((request, ExpectedEnd::from_bounds(false, true)))
+        }
+        RecoveryGap::Cursors {
+            after,
+            upper: CursorGapUpper::EndOfCheckpoint(checkpoint),
+        } => {
+            let options = A::options_mut(&mut request);
+            options.after = Some(after.clone());
+            options.before = None;
+            A::set_end_checkpoint(&mut request, Some(to_exclusive_end_bound(*checkpoint)?));
+            Ok((request, ExpectedEnd::from_bounds(true, false)))
+        }
     }
 }
 
@@ -119,10 +239,23 @@ pub(super) enum RpcEvent<R> {
 }
 
 /// Driver action returned by [`ListMachine::process_event`].
-pub(super) enum ListAction<R> {
-    Frame { response: R, complete: bool },
+pub(super) enum ListAction<R, P> {
+    Frame {
+        response: R,
+        progress: Option<P>,
+        complete: bool,
+    },
     Continue,
     Terminal(Status),
+}
+
+/// How an ascending scan handles `LedgerTip` before its requested bound.
+#[derive(Clone, Copy)]
+pub(super) enum LedgerTipPolicy {
+    /// Complete at the indexed tip.
+    Complete,
+    /// Retry from the served frontier until the fixed bound is indexed.
+    WaitForExpectedBound,
 }
 
 pub(super) struct ListMachine<A: SubscriptionAdapter> {
@@ -130,6 +263,7 @@ pub(super) struct ListMachine<A: SubscriptionAdapter> {
     payload: A::ListRequest,
     expected_end: ExpectedEnd,
     direction: ListScanDirection,
+    ledger_tip_policy: LedgerTipPolicy,
     rpc_state: RpcState<A>,
     /// Snapshot of the starting bound sent in the active request, used to detect bound violations.
     request_start_resume_bound: Option<Bytes>,
@@ -137,11 +271,12 @@ pub(super) struct ListMachine<A: SubscriptionAdapter> {
     latest_cursor: Option<Bytes>,
     /// Most recent progress metadata, used to validate monotonic checkpoint coverage.
     latest_progress: Option<Progress<A::Cursor>>,
+    polling_attempt: u32,
     received_frame_in_request: bool,
     request_has_checkpoint_coverage: bool,
     received_any_frame: bool,
     retry: RetryState,
-    observability: LedgerStreamObservability,
+    pub(super) observability: LedgerStreamObservability,
     stage: LedgerStreamStage,
 }
 
@@ -151,6 +286,7 @@ impl<A: SubscriptionAdapter> ListMachine<A> {
         payload: A::ListRequest,
         expected_end: ExpectedEnd,
         direction: ListScanDirection,
+        ledger_tip_policy: LedgerTipPolicy,
         observability: LedgerStreamObservability,
         stage: LedgerStreamStage,
     ) -> Self {
@@ -159,10 +295,12 @@ impl<A: SubscriptionAdapter> ListMachine<A> {
             payload,
             expected_end,
             direction,
+            ledger_tip_policy,
             rpc_state: RpcState::Idle,
             request_start_resume_bound: None,
             latest_cursor: None,
             latest_progress: None,
+            polling_attempt: 0,
             received_frame_in_request: false,
             request_has_checkpoint_coverage: false,
             received_any_frame: false,
@@ -248,7 +386,7 @@ impl<A: SubscriptionAdapter> ListMachine<A> {
         &mut self,
         event: RpcEvent<A::ListResponse>,
         config: &LedgerStreamConfig,
-    ) -> ListAction<A::ListResponse> {
+    ) -> ListAction<A::ListResponse, Progress<A::Cursor>> {
         match event {
             RpcEvent::Wake => {
                 self.start_dispatch();
@@ -265,7 +403,11 @@ impl<A: SubscriptionAdapter> ListMachine<A> {
             RpcEvent::Frame(response) => {
                 let (item_present, watermark, end) = A::extract_metadata(&response);
                 match self.process_frame_metadata(item_present, watermark, end, config) {
-                    Ok((_progress, complete)) => ListAction::Frame { response, complete },
+                    Ok((progress, complete)) => ListAction::Frame {
+                        response,
+                        progress,
+                        complete,
+                    },
                     Err(status) => ListAction::Terminal(status),
                 }
             }
@@ -297,7 +439,7 @@ impl<A: SubscriptionAdapter> ListMachine<A> {
         item_present: bool,
         watermark: Option<&Watermark>,
         end: Option<&QueryEnd>,
-        _config: &LedgerStreamConfig,
+        config: &LedgerStreamConfig,
     ) -> Result<(Option<Progress<A::Cursor>>, bool)> {
         let watermark =
             watermark.ok_or_else(|| Status::data_loss("List frame is missing its watermark"))?;
@@ -345,6 +487,7 @@ impl<A: SubscriptionAdapter> ListMachine<A> {
         }
         if cursor_changed {
             self.latest_cursor = Some(cursor.clone());
+            self.polling_attempt = 0;
             self.retry.reset(&self.observability);
         }
         if let Some(progress) = &frame_progress {
@@ -414,9 +557,18 @@ impl<A: SubscriptionAdapter> ListMachine<A> {
                             "descending List reached LedgerTip after prior scan progress",
                         ));
                     }
-                    QueryEndReason::LedgerTip => {
+                    QueryEndReason::LedgerTip
+                        if matches!(self.ledger_tip_policy, LedgerTipPolicy::Complete) =>
+                    {
                         self.rpc_state = RpcState::Idle;
                         true
+                    }
+                    QueryEndReason::LedgerTip => {
+                        set_resume_bound::<A>(self.direction, &mut self.payload, cursor.clone());
+                        let delay = backoff_delay(config, self.polling_attempt);
+                        self.polling_attempt = self.polling_attempt.saturating_add(1);
+                        self.sleep(delay);
+                        false
                     }
                     QueryEndReason::Unknown => {
                         return Err(Status::data_loss("List QueryEnd has an unknown reason"));
@@ -451,6 +603,7 @@ impl<A: SubscriptionAdapter> ListDriver<A> {
                 payload,
                 expected_end,
                 direction,
+                LedgerTipPolicy::Complete,
                 observability.clone(),
                 LedgerStreamStage::List,
             )

--- a/crates/sui-rpc/src/client/ledger_streams/list.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/list.rs
@@ -1,0 +1,504 @@
+use futures::StreamExt;
+use prost::bytes::Bytes;
+use std::pin::Pin;
+use std::time::Duration;
+use tonic::Request;
+use tonic::Status;
+use tonic::codegen::BoxStream;
+
+use super::super::Client;
+use super::super::Result;
+use super::adapter::CursorDomain;
+use super::adapter::ListScanDirection;
+use super::adapter::Progress;
+use super::adapter::RpcFuture;
+use super::adapter::SubscriptionAdapter;
+use super::observability::LedgerStreamEvent;
+use super::observability::LedgerStreamObservability;
+use super::observability::LedgerStreamOperation;
+use super::observability::LedgerStreamStage;
+use super::retry::FailurePhase;
+use super::retry::RetryState;
+use super::types::LedgerStreamConfig;
+use crate::proto::sui::rpc::v2::QueryEnd;
+use crate::proto::sui::rpc::v2::QueryEndReason;
+use crate::proto::sui::rpc::v2::Watermark;
+
+/// Permitted `CheckpointBound` and `CursorBound` endings, with or without prior progress.
+#[derive(Clone, Copy)]
+pub(super) struct ExpectedEnd {
+    checkpoint_after_progress: bool,
+    cursor_after_progress: bool,
+    checkpoint_without_prior_progress: bool,
+    cursor_without_prior_progress: bool,
+}
+impl ExpectedEnd {
+    fn accepts(
+        self,
+        reason: QueryEndReason,
+        received_prior_frame: bool,
+        request_started_from_resume_bound: bool,
+    ) -> bool {
+        let (checkpoint, cursor) = if received_prior_frame {
+            (self.checkpoint_after_progress, self.cursor_after_progress)
+        } else {
+            // A resume frontier may immediately return CursorBound when nothing follows it.
+            (
+                self.checkpoint_without_prior_progress,
+                self.cursor_without_prior_progress || request_started_from_resume_bound,
+            )
+        };
+        (checkpoint && reason == QueryEndReason::CheckpointBound)
+            || (cursor && reason == QueryEndReason::CursorBound)
+    }
+}
+
+fn validate_query_end_item(reason: QueryEndReason, item_present: bool) -> Result<()> {
+    if reason == QueryEndReason::ItemLimit && !item_present {
+        Err(Status::data_loss("ItemLimit QueryEnd is missing its item"))
+    } else if reason != QueryEndReason::ItemLimit && item_present {
+        Err(Status::data_loss(
+            "non-ItemLimit QueryEnd unexpectedly contains an item",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub(super) fn determine_expected_end<A: SubscriptionAdapter>(
+    request: &A::ListRequest,
+    direction: ListScanDirection,
+) -> ExpectedEnd {
+    let options = A::options(request);
+    let checkpoint_without_prior_progress = A::start_checkpoint(request).is_some()
+        || A::end_checkpoint(request).is_some()
+        || direction == ListScanDirection::Descending;
+    let cursor_without_prior_progress =
+        options.is_some_and(|options| options.after.is_some() || options.before.is_some());
+    let (checkpoint_after_progress, cursor_after_progress) = match direction {
+        ListScanDirection::Ascending => (
+            A::end_checkpoint(request).is_some(),
+            options.is_some_and(|options| options.before.is_some()),
+        ),
+        ListScanDirection::Descending => {
+            (true, options.is_some_and(|options| options.after.is_some()))
+        }
+    };
+    ExpectedEnd {
+        checkpoint_after_progress,
+        cursor_after_progress,
+        checkpoint_without_prior_progress,
+        cursor_without_prior_progress,
+    }
+}
+
+fn set_resume_bound<A: SubscriptionAdapter>(
+    direction: ListScanDirection,
+    request: &mut A::ListRequest,
+    cursor: Bytes,
+) {
+    direction.set_resume_bound(A::options_mut(request), cursor);
+}
+
+enum RpcState<A: SubscriptionAdapter> {
+    Idle,
+    Dispatch {
+        future: RpcFuture<A::ListResponse>,
+        started_at: Option<tokio::time::Instant>,
+    },
+    Stream(BoxStream<A::ListResponse>),
+    Sleep(Pin<Box<tokio::time::Sleep>>),
+}
+
+/// Raw I/O event produced by [`ListMachine::poll_rpc`].
+pub(super) enum RpcEvent<R> {
+    Frame(R),
+    Status(Status, FailurePhase),
+    Eof,
+    Wake,
+}
+
+/// Driver action returned by [`ListMachine::process_event`].
+pub(super) enum ListAction<R> {
+    Frame { response: R, complete: bool },
+    Continue,
+    Terminal(Status),
+}
+
+pub(super) struct ListMachine<A: SubscriptionAdapter> {
+    client: Client,
+    payload: A::ListRequest,
+    expected_end: ExpectedEnd,
+    direction: ListScanDirection,
+    rpc_state: RpcState<A>,
+    /// Snapshot of the starting bound sent in the active request, used to detect bound violations.
+    request_start_resume_bound: Option<Bytes>,
+    /// Most recent raw wire cursor received, used to populate `after`/`before` when reconnecting.
+    latest_cursor: Option<Bytes>,
+    /// Most recent progress metadata, used to validate monotonic checkpoint coverage.
+    latest_progress: Option<Progress<A::Cursor>>,
+    received_frame_in_request: bool,
+    request_has_checkpoint_coverage: bool,
+    received_any_frame: bool,
+    retry: RetryState,
+    observability: LedgerStreamObservability,
+    stage: LedgerStreamStage,
+}
+
+impl<A: SubscriptionAdapter> ListMachine<A> {
+    pub(super) fn new(
+        client: Client,
+        payload: A::ListRequest,
+        expected_end: ExpectedEnd,
+        direction: ListScanDirection,
+        observability: LedgerStreamObservability,
+        stage: LedgerStreamStage,
+    ) -> Self {
+        let mut machine = Self {
+            client,
+            payload,
+            expected_end,
+            direction,
+            rpc_state: RpcState::Idle,
+            request_start_resume_bound: None,
+            latest_cursor: None,
+            latest_progress: None,
+            received_frame_in_request: false,
+            request_has_checkpoint_coverage: false,
+            received_any_frame: false,
+            retry: RetryState::new(A::FAMILY, LedgerStreamOperation::List),
+            observability,
+            stage,
+        };
+        machine.start_dispatch();
+        machine
+    }
+
+    fn start_dispatch(&mut self) {
+        self.received_frame_in_request = false;
+        self.request_has_checkpoint_coverage = false;
+        self.request_start_resume_bound = A::options(&self.payload)
+            .and_then(|options| self.direction.resume_bound(options).clone());
+        let request = Request::new(self.payload.clone());
+        self.rpc_state = RpcState::Dispatch {
+            future: A::dispatch_list(self.client.clone(), request),
+            started_at: None,
+        };
+    }
+
+    fn sleep(&mut self, delay: Duration) {
+        self.rpc_state = RpcState::Sleep(Box::pin(tokio::time::sleep(delay)));
+    }
+
+    /// Dropping this future preserves `self.rpc_state`, so the next call resumes rather than
+    /// restarts in-flight work.
+    pub(super) async fn poll_rpc(&mut self) -> RpcEvent<A::ListResponse> {
+        loop {
+            match &mut self.rpc_state {
+                RpcState::Idle => {
+                    return RpcEvent::Status(
+                        Status::internal("idle RPC state polled"),
+                        FailurePhase::Dispatch,
+                    );
+                }
+                RpcState::Dispatch { future, started_at } => {
+                    // The timer starts on the first poll and survives cancellation by gap buffering.
+                    if started_at.is_none() {
+                        *started_at = self.observability.start_timer();
+                    }
+                    let rpc_started_at = started_at.as_ref().cloned();
+                    let result = future.await;
+                    self.observability.emit_rpc_response(
+                        rpc_started_at,
+                        A::FAMILY,
+                        LedgerStreamOperation::List,
+                        self.stage,
+                        &result,
+                    );
+                    match result {
+                        Ok(stream) => self.rpc_state = RpcState::Stream(stream),
+                        Err(status) => {
+                            self.rpc_state = RpcState::Idle;
+                            return RpcEvent::Status(status, FailurePhase::Dispatch);
+                        }
+                    }
+                }
+                RpcState::Stream(stream) => match stream.next().await {
+                    Some(Ok(response)) => return RpcEvent::Frame(response),
+                    Some(Err(status)) => {
+                        self.rpc_state = RpcState::Idle;
+                        return RpcEvent::Status(status, FailurePhase::Body);
+                    }
+                    None => {
+                        self.rpc_state = RpcState::Idle;
+                        return RpcEvent::Eof;
+                    }
+                },
+                RpcState::Sleep(sleep) => {
+                    sleep.as_mut().await;
+                    self.rpc_state = RpcState::Idle;
+                    return RpcEvent::Wake;
+                }
+            }
+        }
+    }
+
+    /// Advances validation and pagination state with one RPC event.
+    pub(super) fn process_event(
+        &mut self,
+        event: RpcEvent<A::ListResponse>,
+        config: &LedgerStreamConfig,
+    ) -> ListAction<A::ListResponse> {
+        match event {
+            RpcEvent::Wake => {
+                self.start_dispatch();
+                ListAction::Continue
+            }
+            // Successful List streams end with QueryEnd; bare EOF has no completion boundary.
+            RpcEvent::Eof => ListAction::Terminal(Status::data_loss(
+                "List stream ended before its QueryEnd frame",
+            )),
+            RpcEvent::Status(status, phase) => match self.process_status(status, phase, config) {
+                Ok(()) => ListAction::Continue,
+                Err(status) => ListAction::Terminal(status),
+            },
+            RpcEvent::Frame(response) => {
+                let (item_present, watermark, end) = A::extract_metadata(&response);
+                match self.process_frame_metadata(item_present, watermark, end, config) {
+                    Ok((_progress, complete)) => ListAction::Frame { response, complete },
+                    Err(status) => ListAction::Terminal(status),
+                }
+            }
+        }
+    }
+
+    fn process_status(
+        &mut self,
+        status: Status,
+        phase: FailurePhase,
+        config: &LedgerStreamConfig,
+    ) -> Result<()> {
+        if let Some(cursor) = self.latest_cursor.clone() {
+            set_resume_bound::<A>(self.direction, &mut self.payload, cursor);
+        }
+        if let Some(delay) =
+            self.retry
+                .retry_delay(&status, phase, config, &self.observability, self.stage)
+        {
+            self.sleep(delay);
+            Ok(())
+        } else {
+            Err(status)
+        }
+    }
+
+    fn process_frame_metadata(
+        &mut self,
+        item_present: bool,
+        watermark: Option<&Watermark>,
+        end: Option<&QueryEnd>,
+        _config: &LedgerStreamConfig,
+    ) -> Result<(Option<Progress<A::Cursor>>, bool)> {
+        let watermark =
+            watermark.ok_or_else(|| Status::data_loss("List frame is missing its watermark"))?;
+        let cursor = watermark
+            .cursor
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| Status::data_loss("List watermark is missing its cursor"))?;
+
+        let checkpoint = watermark.checkpoint;
+        if checkpoint.is_none() && self.request_has_checkpoint_coverage {
+            return Err(Status::data_loss(
+                "List checkpoint coverage became unavailable",
+            ));
+        }
+        if checkpoint.is_some() {
+            self.request_has_checkpoint_coverage = true;
+        }
+        let received_prior_frame_in_request = self.received_frame_in_request;
+        let received_prior_frame_ever = self.received_any_frame;
+        if item_present
+            && end.is_none()
+            && !received_prior_frame_in_request
+            && self.request_start_resume_bound.as_ref() == Some(&cursor)
+        {
+            return Err(Status::data_loss(
+                "List item cursor equals its exclusive request resume bound",
+            ));
+        }
+        let mut frame_progress = A::Cursor::position(&cursor, checkpoint);
+        if frame_progress.is_none() && item_present {
+            return Err(Status::data_loss(
+                "List item watermark names no resumable position",
+            ));
+        }
+        if let (Some(previous), Some(next)) = (&self.latest_progress, &mut frame_progress) {
+            next.inherit_checkpoint_coverage(previous);
+            previous.validate_list_successor(next, self.direction)?;
+        }
+        self.received_frame_in_request = true;
+        self.received_any_frame = true;
+        let cursor_changed = self.latest_cursor.as_ref() != Some(&cursor);
+        if item_present && !cursor_changed {
+            return Err(Status::data_loss("List item repeated its cursor"));
+        }
+        if cursor_changed {
+            self.latest_cursor = Some(cursor.clone());
+            self.retry.reset(&self.observability);
+        }
+        if let Some(progress) = &frame_progress {
+            self.latest_progress = Some(progress.clone());
+        }
+
+        let complete = match end {
+            None => false,
+            Some(end) => {
+                let reason = end
+                    .reason
+                    .and_then(|reason| QueryEndReason::try_from(reason).ok())
+                    .filter(|reason| *reason != QueryEndReason::Unknown)
+                    .ok_or_else(|| {
+                        Status::data_loss("List QueryEnd has a missing or unknown reason")
+                    })?;
+                validate_query_end_item(reason, item_present)?;
+                if reason == QueryEndReason::CheckpointBound {
+                    A::validate_checkpoint_bound(&self.payload, self.direction, checkpoint)?;
+                }
+
+                match reason {
+                    QueryEndReason::ItemLimit => {
+                        if self.request_start_resume_bound.as_ref() == Some(&cursor) {
+                            return Err(Status::data_loss(
+                                "ItemLimit QueryEnd did not advance its cursor",
+                            ));
+                        }
+                        set_resume_bound::<A>(self.direction, &mut self.payload, cursor.clone());
+                        self.start_dispatch();
+                        false
+                    }
+                    QueryEndReason::ScanLimit => {
+                        if self.request_start_resume_bound.as_ref() == Some(&cursor) {
+                            return Err(Status::data_loss(
+                                "ScanLimit QueryEnd did not advance its cursor",
+                            ));
+                        }
+                        set_resume_bound::<A>(self.direction, &mut self.payload, cursor.clone());
+                        self.start_dispatch();
+                        false
+                    }
+                    QueryEndReason::CheckpointBound | QueryEndReason::CursorBound => {
+                        if !self.expected_end.accepts(
+                            reason,
+                            received_prior_frame_in_request,
+                            self.request_start_resume_bound.is_some(),
+                        ) {
+                            return Err(Status::data_loss("List ended at an unexpected bound"));
+                        }
+                        self.rpc_state = RpcState::Idle;
+                        true
+                    }
+                    // A descending interval entirely beyond the indexed tip ends at LedgerTip.
+                    QueryEndReason::LedgerTip
+                        if self.direction == ListScanDirection::Descending
+                            && !received_prior_frame_ever =>
+                    {
+                        self.rpc_state = RpcState::Idle;
+                        true
+                    }
+                    // After progress, a descending scan cannot legitimately reach LedgerTip.
+                    QueryEndReason::LedgerTip
+                        if self.direction == ListScanDirection::Descending =>
+                    {
+                        return Err(Status::data_loss(
+                            "descending List reached LedgerTip after prior scan progress",
+                        ));
+                    }
+                    QueryEndReason::LedgerTip => {
+                        self.rpc_state = RpcState::Idle;
+                        true
+                    }
+                    QueryEndReason::Unknown => {
+                        return Err(Status::data_loss("List QueryEnd has an unknown reason"));
+                    }
+                }
+            }
+        };
+
+        Ok((frame_progress, complete))
+    }
+}
+
+/// Drives a finite List operation by resuming the request cursor and yielding whole responses.
+pub(super) struct ListDriver<A: SubscriptionAdapter> {
+    machine: Option<ListMachine<A>>,
+    config: LedgerStreamConfig,
+    observability: LedgerStreamObservability,
+    terminal: Option<Status>,
+    done: bool,
+}
+
+impl<A: SubscriptionAdapter> ListDriver<A> {
+    pub(super) fn new(client: Client, request: A::ListRequest, config: LedgerStreamConfig) -> Self {
+        let observability = LedgerStreamObservability::new(config.observer());
+        let payload = request;
+        let direction = ListScanDirection::from_request::<A>(&payload);
+        let terminal = direction.as_ref().err().cloned();
+        let machine = direction.ok().map(|direction| {
+            let expected_end = determine_expected_end::<A>(&payload, direction);
+            ListMachine::new(
+                client,
+                payload,
+                expected_end,
+                direction,
+                observability.clone(),
+                LedgerStreamStage::List,
+            )
+        });
+        Self {
+            machine,
+            config,
+            observability,
+            terminal,
+            done: false,
+        }
+    }
+
+    pub(super) async fn next(&mut self) -> Option<Result<A::ListResponse>> {
+        if self.done {
+            return None;
+        }
+        if let Some(status) = self.terminal.take() {
+            return Some(self.finish_terminal(status));
+        }
+
+        loop {
+            let machine = self.machine.as_mut()?;
+            let event = machine.poll_rpc().await;
+            match machine.process_event(event, &self.config) {
+                ListAction::Frame {
+                    response, complete, ..
+                } => {
+                    if complete {
+                        self.done = true;
+                        self.machine = None;
+                    }
+                    return Some(Ok(response));
+                }
+                ListAction::Continue => {}
+                ListAction::Terminal(status) => return Some(self.finish_terminal(status)),
+            }
+        }
+    }
+
+    fn finish_terminal(&mut self, status: Status) -> Result<A::ListResponse> {
+        self.observability
+            .emit(|| LedgerStreamEvent::TerminalError {
+                family: A::FAMILY,
+                status: status.clone(),
+            });
+        self.done = true;
+        self.machine = None;
+        Err(status)
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/mod.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/mod.rs
@@ -1,10 +1,16 @@
-//! Finite ledger List facades, with shared family adapters, validation, pagination, and retry.
+//! Resumable checkpoint, transaction, and event facades.
+//!
+//! `facade` exposes the APIs; `list` validates and paginates List responses; `stream` drives
+//! historical replay plus Poll or Subscribe tails; and `subscription` buffers live frames during
+//! gap repair. Adapters, retry, observability, and types provide shared protocol support.
 
 mod adapter;
 mod facade;
 mod list;
 mod observability;
 mod retry;
+mod stream;
+mod subscription;
 mod types;
 
 pub use observability::LedgerStreamEvent;

--- a/crates/sui-rpc/src/client/ledger_streams/mod.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/mod.rs
@@ -1,7 +1,10 @@
-//! Resumable checkpoint, transaction, and event stream vocabulary for the Sui RPC client.
+//! Finite ledger List facades, with shared family adapters, validation, pagination, and retry.
 
+mod adapter;
 mod facade;
+mod list;
 mod observability;
+mod retry;
 mod types;
 
 pub use observability::LedgerStreamEvent;

--- a/crates/sui-rpc/src/client/ledger_streams/mod.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/mod.rs
@@ -1,0 +1,23 @@
+//! Resumable checkpoint, transaction, and event stream vocabulary for the Sui RPC client.
+
+mod facade;
+mod observability;
+mod types;
+
+pub use observability::LedgerStreamEvent;
+pub use observability::LedgerStreamFamily;
+pub use observability::LedgerStreamOperation;
+pub use observability::LedgerStreamStage;
+pub use observability::ListEvent;
+pub use types::CheckpointStreamFrame;
+pub use types::CheckpointStreamRequest;
+pub use types::CheckpointStreamStart;
+pub use types::Delivery;
+pub use types::EventStreamFrame;
+pub use types::EventStreamRequest;
+pub use types::EventStreamStart;
+pub use types::LedgerStreamConfig;
+pub use types::ListConfig;
+pub use types::TransactionStreamFrame;
+pub use types::TransactionStreamRequest;
+pub use types::TransactionStreamStart;

--- a/crates/sui-rpc/src/client/ledger_streams/observability.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/observability.rs
@@ -1,0 +1,234 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tonic::Code;
+use tonic::Status;
+
+use super::super::Result;
+
+/// The ledger protocol family associated with an observability event.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum LedgerStreamFamily {
+    Checkpoint,
+    Transaction,
+    Event,
+}
+
+/// The RPC operation associated with an observability event.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum LedgerStreamOperation {
+    List,
+    GetServiceInfo,
+    Subscribe,
+}
+
+/// List operations use `List`; stream operations use the remaining stages.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum LedgerStreamStage {
+    List,
+    InitialReplay,
+    LiveTipStartup,
+    PollingBaseline,
+    PollingTail,
+    GapRecovery,
+    LiveSubscription,
+}
+
+/// Observability events emitted by ledger streams.
+///
+/// Label metrics by family, operation, stage, and status code. Record counts and durations as
+/// values; keep status messages and metadata in logs.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum LedgerStreamEvent {
+    /// A generated RPC future resolved.
+    ///
+    /// For List and Subscribe, `elapsed` measures dispatch-to-response-headers latency, not
+    /// response-body processing or subscription lifetime.
+    #[non_exhaustive]
+    RpcResponse {
+        family: LedgerStreamFamily,
+        operation: LedgerStreamOperation,
+        stage: LedgerStreamStage,
+        code: Code,
+        elapsed: Duration,
+    },
+    /// A classified transient failure scheduled another attempt.
+    #[non_exhaustive]
+    RetryScheduled {
+        family: LedgerStreamFamily,
+        operation: LedgerStreamOperation,
+        stage: LedgerStreamStage,
+        status: Status,
+        consecutive_failures: u32,
+        delay: Duration,
+    },
+    /// Operation progress ended a period of consecutive transient failures.
+    #[non_exhaustive]
+    RetryRecovered {
+        family: LedgerStreamFamily,
+        operation: LedgerStreamOperation,
+        started_in: LedgerStreamStage,
+        consecutive_failures: u32,
+        elapsed: Duration,
+    },
+    /// An established Subscribe response body returned an error or ended unexpectedly.
+    #[non_exhaustive]
+    SubscriptionStreamInterrupted {
+        family: LedgerStreamFamily,
+        stage: LedgerStreamStage,
+        status: Status,
+    },
+    /// The stream began a bounded List replay for a subscription gap.
+    #[non_exhaustive]
+    GapRecoveryStarted { family: LedgerStreamFamily },
+    /// List gap buffering reached its configured item-bearing frame limit.
+    #[non_exhaustive]
+    SubscriptionBufferLimitReached {
+        family: LedgerStreamFamily,
+        buffered_items: usize,
+        limit: usize,
+    },
+    /// A non-retryable terminal error that will be yielded as the next stream item.
+    #[non_exhaustive]
+    TerminalError {
+        family: LedgerStreamFamily,
+        status: Status,
+    },
+}
+
+/// Observability events emitted by finite List operations.
+///
+/// Label metrics by family and status code. Record counts and durations as values; keep status
+/// messages and metadata in logs.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum ListEvent {
+    /// A generated List RPC future resolved.
+    ///
+    /// `elapsed` measures dispatch-to-response-headers latency, not response-body processing.
+    #[non_exhaustive]
+    RpcResponse {
+        family: LedgerStreamFamily,
+        code: Code,
+        elapsed: Duration,
+    },
+    /// A classified transient failure scheduled another attempt.
+    #[non_exhaustive]
+    RetryScheduled {
+        family: LedgerStreamFamily,
+        status: Status,
+        consecutive_failures: u32,
+        delay: Duration,
+    },
+    /// Operation progress ended a period of consecutive transient failures.
+    #[non_exhaustive]
+    RetryRecovered {
+        family: LedgerStreamFamily,
+        consecutive_failures: u32,
+        elapsed: Duration,
+    },
+    /// A non-retryable terminal error that will be yielded as the next stream item.
+    #[non_exhaustive]
+    TerminalError {
+        family: LedgerStreamFamily,
+        status: Status,
+    },
+}
+
+impl ListEvent {
+    pub(super) fn from_stream_event(event: LedgerStreamEvent) -> Option<Self> {
+        match event {
+            LedgerStreamEvent::RpcResponse {
+                family,
+                operation: LedgerStreamOperation::List,
+                code,
+                elapsed,
+                ..
+            } => Some(Self::RpcResponse {
+                family,
+                code,
+                elapsed,
+            }),
+            LedgerStreamEvent::RetryScheduled {
+                family,
+                operation: LedgerStreamOperation::List,
+                status,
+                consecutive_failures,
+                delay,
+                ..
+            } => Some(Self::RetryScheduled {
+                family,
+                status,
+                consecutive_failures,
+                delay,
+            }),
+            LedgerStreamEvent::RetryRecovered {
+                family,
+                operation: LedgerStreamOperation::List,
+                consecutive_failures,
+                elapsed,
+                ..
+            } => Some(Self::RetryRecovered {
+                family,
+                consecutive_failures,
+                elapsed,
+            }),
+            LedgerStreamEvent::TerminalError { family, status } => {
+                Some(Self::TerminalError { family, status })
+            }
+            _ => None,
+        }
+    }
+}
+
+pub(super) type ListObserver = Arc<dyn Fn(ListEvent) + Send + Sync + 'static>;
+
+pub(super) type LedgerStreamObserver = Arc<dyn Fn(LedgerStreamEvent) + Send + Sync + 'static>;
+
+#[derive(Clone, Default)]
+pub(super) struct LedgerStreamObservability {
+    observer: Option<LedgerStreamObserver>,
+}
+
+impl LedgerStreamObservability {
+    pub(super) fn new(observer: Option<LedgerStreamObserver>) -> Self {
+        Self { observer }
+    }
+
+    pub(super) fn emit(&self, event: impl FnOnce() -> LedgerStreamEvent) {
+        if let Some(observer) = &self.observer {
+            observer(event());
+        }
+    }
+
+    pub(super) fn start_timer(&self) -> Option<tokio::time::Instant> {
+        self.observer.as_ref().map(|_| tokio::time::Instant::now())
+    }
+
+    pub(super) fn emit_rpc_response<T>(
+        &self,
+        started_at: Option<tokio::time::Instant>,
+        family: LedgerStreamFamily,
+        operation: LedgerStreamOperation,
+        stage: LedgerStreamStage,
+        result: &Result<T>,
+    ) {
+        let Some(started_at) = started_at else {
+            return;
+        };
+        let code = result
+            .as_ref()
+            .map_or_else(|status| status.code(), |_| Code::Ok);
+        self.emit(|| LedgerStreamEvent::RpcResponse {
+            family,
+            operation,
+            stage,
+            code,
+            elapsed: started_at.elapsed(),
+        });
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/retry.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/retry.rs
@@ -1,0 +1,186 @@
+use std::collections::hash_map::RandomState;
+use std::error::Error as _;
+use std::hash::BuildHasher;
+use std::time::Duration;
+
+use tonic::Code;
+use tonic::Status;
+
+use super::observability::LedgerStreamEvent;
+use super::observability::LedgerStreamFamily;
+use super::observability::LedgerStreamObservability;
+use super::observability::LedgerStreamOperation;
+use super::observability::LedgerStreamStage;
+use super::types::LedgerStreamConfig;
+
+/// Where an error was encountered during an RPC interaction.
+///
+/// Tonic surfaces errors differently depending on whether the RPC failed while initiating the call
+/// or while reading frames from an already-open response stream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum FailurePhase {
+    /// Failed while sending the initial RPC request.
+    Dispatch,
+    /// Failed while reading chunks from the response stream.
+    Body,
+}
+
+/// Classifies failures eligible for automatic retry.
+///
+/// `Unavailable`, `DeadlineExceeded`, `ResourceExhausted`, and `Aborted` are always retried.
+///
+/// `Cancelled` and `Unknown` use two heuristics based on where the error was observed:
+/// - During `Dispatch` (initiating the RPC), server-sent `Cancelled` and `Unknown` are
+///   conservatively treated as terminal. We only retry if Tonic attached an underlying error source
+///   (`status.source().is_some()`), treating that as evidence of a lower-layer transport or connection
+///   failure.
+/// - During `Body` (streaming responses), stream interruptions (such as Envoy, ALB, or NAT gateway
+///   timeouts resetting an HTTP/2 stream) surface through Tonic as `Cancelled` or `Unknown`. Because
+///   `stream.next()` surfaces transport drops and server trailers identically, we treat body-phase
+///   `Cancelled` and `Unknown` as retryable based on the observation phase alone, allowing the stream
+///   to reconnect and resume from the latest cursor.
+///
+/// All other statuses are terminal.
+fn transient(status: &Status, phase: FailurePhase) -> bool {
+    let dispatch_transient = matches!(
+        status.code(),
+        Code::Unavailable | Code::DeadlineExceeded | Code::ResourceExhausted | Code::Aborted
+    );
+    let reset_code = matches!(status.code(), Code::Cancelled | Code::Unknown);
+    let transport_reset = reset_code && (phase == FailurePhase::Body || status.source().is_some());
+    dispatch_transient || transport_reset
+}
+
+pub(super) struct RetryState {
+    family: LedgerStreamFamily,
+    operation: LedgerStreamOperation,
+    consecutive_errors: u32,
+    first_failure: Option<tokio::time::Instant>,
+    started_in: Option<LedgerStreamStage>,
+}
+
+impl RetryState {
+    pub(super) fn new(family: LedgerStreamFamily, operation: LedgerStreamOperation) -> Self {
+        Self {
+            family,
+            operation,
+            consecutive_errors: 0,
+            first_failure: None,
+            started_in: None,
+        }
+    }
+
+    pub(super) fn reset(&mut self, observability: &LedgerStreamObservability) {
+        if self.consecutive_errors == 0 {
+            return;
+        }
+        let consecutive_failures = self.consecutive_errors;
+        self.consecutive_errors = 0;
+        let first_failure = self.first_failure.take();
+        let started_in = self.started_in.take();
+        if let (Some(first_failure), Some(started_in)) = (first_failure, started_in) {
+            observability.emit(|| LedgerStreamEvent::RetryRecovered {
+                family: self.family,
+                operation: self.operation,
+                started_in,
+                consecutive_failures,
+                elapsed: first_failure.elapsed(),
+            });
+        }
+    }
+
+    pub(super) fn retry_delay(
+        &mut self,
+        status: &Status,
+        phase: FailurePhase,
+        config: &LedgerStreamConfig,
+        observability: &LedgerStreamObservability,
+        stage: LedgerStreamStage,
+    ) -> Option<Duration> {
+        if !transient(status, phase) {
+            return None;
+        }
+
+        let attempt = self.consecutive_errors;
+        self.consecutive_errors = self.consecutive_errors.saturating_add(1);
+        if attempt == 0 {
+            let first_failure = observability.start_timer();
+            self.started_in = first_failure.as_ref().map(|_| stage);
+            self.first_failure = first_failure;
+        }
+        let delay = backoff_delay(config, attempt);
+        let consecutive_failures = self.consecutive_errors;
+        observability.emit(|| LedgerStreamEvent::RetryScheduled {
+            family: self.family,
+            operation: self.operation,
+            stage,
+            status: status.clone(),
+            consecutive_failures,
+            delay,
+        });
+        Some(delay)
+    }
+}
+
+pub(super) fn backoff_delay(config: &LedgerStreamConfig, attempt: u32) -> Duration {
+    let multiplier = 2_u32.saturating_pow(attempt);
+    let exponential = config.base_retry_delay.saturating_mul(multiplier);
+    let capped = exponential.min(config.max_retry_delay);
+    capped.saturating_add(random_jitter(config.retry_jitter))
+}
+
+fn random_jitter(maximum: Duration) -> Duration {
+    if maximum.is_zero() {
+        return Duration::ZERO;
+    }
+    let maximum_nanos = u64::try_from(maximum.as_nanos()).unwrap_or(u64::MAX);
+    // Hashing with a fresh `RandomState`, randomly seeded per instance, yields an unpredictable
+    // sample without a `rand` dependency.
+    let sample = RandomState::new().hash_one(());
+    let jitter_nanos = if maximum_nanos == u64::MAX {
+        sample
+    } else {
+        sample % (maximum_nanos + 1)
+    };
+    Duration::from_nanos(jitter_nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_is_terminal_in_both_phases() {
+        let status = Status::internal("client idle-body watchdog task panicked");
+        assert!(!transient(&status, FailurePhase::Body));
+        assert!(!transient(&status, FailurePhase::Dispatch));
+    }
+
+    #[test]
+    fn server_reported_stream_reset_codes_are_transient_only_mid_body() {
+        for status in [
+            Status::cancelled("server cancelled request"),
+            Status::unknown("server failed request"),
+        ] {
+            assert!(transient(&status, FailurePhase::Body));
+            assert!(!transient(&status, FailurePhase::Dispatch));
+        }
+    }
+
+    #[test]
+    fn transport_sourced_unknown_is_transient_during_dispatch() {
+        let status = Status::from_error(Box::new(std::io::Error::from(
+            std::io::ErrorKind::ConnectionReset,
+        )));
+        assert_eq!(status.code(), Code::Unknown);
+        assert!(status.source().is_some());
+        assert!(transient(&status, FailurePhase::Dispatch));
+    }
+
+    #[test]
+    fn dispatch_set_is_transient_in_both_phases() {
+        let status = Status::unavailable("connection refused");
+        assert!(transient(&status, FailurePhase::Dispatch));
+        assert!(transient(&status, FailurePhase::Body));
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/stream.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/stream.rs
@@ -1,0 +1,1264 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+use tonic::Request;
+use tonic::Status;
+use tonic::codegen::BoxStream;
+
+use super::super::Client;
+use super::super::Result;
+use super::adapter::CursorDomain;
+use super::adapter::ListResponseParts;
+use super::adapter::ListScanDirection;
+use super::adapter::LiveFrame;
+use super::adapter::Progress;
+use super::adapter::ProgressAdvance;
+use super::adapter::Recovery;
+use super::adapter::RecoveryGap;
+use super::adapter::SubscriptionAdapter;
+use super::adapter::validate_caller_read_mask;
+use super::list::LedgerTipPolicy;
+use super::list::ListAction;
+use super::list::ListMachine;
+use super::list::build_initial_list_request;
+use super::list::build_live_tip_baseline_list_request;
+use super::list::build_polling_list_request;
+use super::list::build_recovery_list_request;
+use super::observability::LedgerStreamEvent;
+use super::observability::LedgerStreamObservability;
+use super::observability::LedgerStreamOperation;
+use super::observability::LedgerStreamStage;
+use super::retry::FailurePhase;
+use super::retry::RetryState;
+use super::subscription::BufferedSubscriptionDrain;
+use super::subscription::BufferedSubscriptionState;
+use super::subscription::GapReplay;
+use super::subscription::LiveSubscription;
+use super::types::Delivery;
+use super::types::LedgerStreamConfig;
+use crate::proto::sui::rpc::v2::GetServiceInfoRequest;
+use crate::proto::sui::rpc::v2::Watermark;
+use prost::bytes::Bytes;
+
+enum Phase<A: SubscriptionAdapter> {
+    Prologue(ProloguePhase<A>),
+    Subscribing(SubscribingPhase<A>),
+    Polling(PollingPhase<A>),
+    Terminal(Status),
+    Done,
+}
+
+pub(super) enum Start {
+    Tip,
+    Checkpoint(u64),
+    After(Bytes),
+}
+
+enum ProloguePhase<A: SubscriptionAdapter> {
+    ReadInitialTip,
+    Replay {
+        // `Phase` moves by value; prologue replay allocates this boxed machine once.
+        list_machine: Box<ListMachine<A>>,
+        target_checkpoint: u64,
+    },
+}
+
+enum SubscribingPhase<A: SubscriptionAdapter> {
+    Connect(ConnectMachine<A>),
+    MuteUntilCommitted(LiveSubscription<A>),
+    GapReplay(Box<GapReplay<A>>),
+    DrainGapBuffer(BufferedSubscriptionDrain<A>),
+    Live(LiveSubscription<A>),
+}
+
+struct ConnectMachine<A: SubscriptionAdapter> {
+    context: ConnectContext,
+    phase: ConnectPhase<A>,
+}
+
+#[derive(Clone, Copy)]
+enum ConnectContext {
+    LiveTipStartup,
+    Resume,
+}
+
+enum ConnectPhase<A: SubscriptionAdapter> {
+    Attempt,
+    RetryDelay {
+        delay: Duration,
+    },
+    ReadRecoveryTip,
+    ReplayToRecoveryTip {
+        list_machine: Box<ListMachine<A>>,
+        target_checkpoint: u64,
+        output: ReplayOutput,
+    },
+}
+
+enum PollingPhase<A: SubscriptionAdapter> {
+    ReadBaselineTip,
+    Replay {
+        list_machine: Box<ListMachine<A>>,
+        target_checkpoint: u64,
+        output: ReplayOutput,
+    },
+    Sleep,
+    ReadTip,
+}
+
+#[derive(Clone, Copy)]
+enum ReplayOutput {
+    Suppress,
+    Yield,
+}
+
+struct ReplayFrame<I, P> {
+    item: Option<I>,
+    watermark: Watermark,
+    progress: Option<P>,
+}
+
+fn parse_replay_frame<A: SubscriptionAdapter>(
+    response: A::ListResponse,
+    progress: Option<Progress<A::Cursor>>,
+) -> Result<ReplayFrame<A::Item, Progress<A::Cursor>>> {
+    let ListResponseParts {
+        item, watermark, ..
+    } = A::split_list(response)?;
+    let watermark =
+        watermark.ok_or_else(|| Status::data_loss("List frame is missing its watermark"))?;
+    Ok(ReplayFrame {
+        item,
+        watermark,
+        progress,
+    })
+}
+
+enum ReplayStep<A: SubscriptionAdapter> {
+    Yield(A::Output),
+    Complete,
+    Continue,
+    Terminal(Status),
+}
+
+enum SubscriptionAttempt<A: SubscriptionAdapter> {
+    Established {
+        stream: BoxStream<A::SubscribeResponse>,
+        first_frame: LiveFrame<A::Item, Progress<A::Cursor>>,
+    },
+    Failed {
+        status: Status,
+        failure_phase: FailurePhase,
+    },
+}
+
+enum SubscribingStep<A: SubscriptionAdapter> {
+    Next(SubscribingPhase<A>),
+    Yield(SubscribingPhase<A>, A::Output),
+    Terminal(Status),
+}
+
+enum PollingStep<A: SubscriptionAdapter> {
+    Next(PollingPhase<A>),
+    Yield(PollingPhase<A>, A::Output),
+    Terminal(Status),
+}
+
+async fn dispatch_subscription<A: SubscriptionAdapter>(
+    client: &Client,
+    observability: &LedgerStreamObservability,
+    request: Request<A::SubscribeRequest>,
+    observability_stage: LedgerStreamStage,
+) -> Result<BoxStream<A::SubscribeResponse>> {
+    let future = A::dispatch_subscribe(client.clone(), request);
+    let started_at = observability.start_timer();
+    let result = future.await;
+    observability.emit_rpc_response(
+        started_at,
+        A::FAMILY,
+        LedgerStreamOperation::Subscribe,
+        observability_stage,
+        &result,
+    );
+    result
+}
+
+pub(super) struct Driver<A: SubscriptionAdapter> {
+    client: Client,
+    list_template: A::ListRequest,
+    subscribe_payload: A::SubscribeRequest,
+    item_required: bool,
+    config: LedgerStreamConfig,
+    observability: LedgerStreamObservability,
+    service_info_retry: RetryState,
+    subscription_retry: RetryState,
+    delivery: Delivery,
+    phase: Option<Phase<A>>,
+    committed_progress: Option<Progress<A::Cursor>>,
+    committed_item_position: Option<A::ItemPosition>,
+    last_covered_checkpoint_height: Option<u64>,
+}
+
+impl<A: SubscriptionAdapter> Driver<A> {
+    pub(super) fn new_stream(
+        client: Client,
+        subscribe_payload: A::SubscribeRequest,
+        mut list_template: A::ListRequest,
+        start: Start,
+        delivery: Delivery,
+        config: LedgerStreamConfig,
+    ) -> Self {
+        let observability = LedgerStreamObservability::new(config.observer());
+        let item_required = A::item_required(&subscribe_payload);
+        let requested_phase = match start {
+            Start::Tip => match delivery {
+                Delivery::Subscribe => {
+                    Phase::Subscribing(SubscribingPhase::Connect(ConnectMachine {
+                        context: ConnectContext::LiveTipStartup,
+                        phase: ConnectPhase::Attempt,
+                    }))
+                }
+                Delivery::Poll => Phase::Polling(PollingPhase::ReadBaselineTip),
+            },
+            Start::Checkpoint(checkpoint) => {
+                A::set_start_checkpoint(&mut list_template, Some(checkpoint));
+                Phase::Prologue(ProloguePhase::ReadInitialTip)
+            }
+            Start::After(cursor) => {
+                A::options_mut(&mut list_template).after = Some(cursor);
+                Phase::Prologue(ProloguePhase::ReadInitialTip)
+            }
+        };
+        let phase = if config.ledger_tip_poll_interval == Duration::ZERO {
+            Phase::Terminal(Status::invalid_argument(
+                "ledger_tip_poll_interval must be greater than zero",
+            ))
+        } else if let Err(status) =
+            validate_caller_read_mask::<A>(A::list_read_mask(&list_template))
+        {
+            Phase::Terminal(status)
+        } else {
+            requested_phase
+        };
+        Self {
+            client,
+            list_template,
+            subscribe_payload,
+            item_required,
+            config,
+            observability,
+            service_info_retry: RetryState::new(A::FAMILY, LedgerStreamOperation::GetServiceInfo),
+            subscription_retry: RetryState::new(A::FAMILY, LedgerStreamOperation::Subscribe),
+            delivery,
+            phase: Some(phase),
+            committed_progress: None,
+            committed_item_position: None,
+            last_covered_checkpoint_height: None,
+        }
+    }
+
+    pub(super) async fn next(&mut self) -> Option<Result<A::Output>> {
+        loop {
+            let phase = self.phase.take().unwrap_or(Phase::Done);
+            match phase {
+                Phase::Done => {
+                    self.phase = Some(Phase::Done);
+                    return None;
+                }
+                Phase::Terminal(status) => {
+                    self.observability
+                        .emit(|| LedgerStreamEvent::TerminalError {
+                            family: A::FAMILY,
+                            status: status.clone(),
+                        });
+                    self.phase = Some(Phase::Done);
+                    return Some(Err(status));
+                }
+                Phase::Prologue(phase) => {
+                    let (next_phase, output) = self.step_prologue(phase).await;
+                    self.phase = Some(next_phase);
+                    if let Some(output) = output {
+                        return Some(Ok(output));
+                    }
+                }
+                Phase::Subscribing(phase) => match self.step_subscribing(phase).await {
+                    SubscribingStep::Next(next) => {
+                        self.phase = Some(Phase::Subscribing(next));
+                    }
+                    SubscribingStep::Yield(next, output) => {
+                        self.phase = Some(Phase::Subscribing(next));
+                        return Some(Ok(output));
+                    }
+                    SubscribingStep::Terminal(status) => {
+                        self.phase = Some(Phase::Terminal(status));
+                    }
+                },
+                Phase::Polling(phase) => match self.step_polling(phase).await {
+                    PollingStep::Next(next) => {
+                        self.phase = Some(Phase::Polling(next));
+                    }
+                    PollingStep::Yield(next, output) => {
+                        self.phase = Some(Phase::Polling(next));
+                        return Some(Ok(output));
+                    }
+                    PollingStep::Terminal(status) => {
+                        self.phase = Some(Phase::Terminal(status));
+                    }
+                },
+            }
+        }
+    }
+
+    async fn step_prologue(&mut self, phase: ProloguePhase<A>) -> (Phase<A>, Option<A::Output>) {
+        match phase {
+            ProloguePhase::ReadInitialTip => match self
+                .read_service_checkpoint_height(LedgerStreamStage::InitialReplay)
+                .await
+            {
+                Err(status) => (Phase::Terminal(status), None),
+                // Wait for `start_checkpoint`; otherwise `[start_checkpoint, checkpoint_height + 1)`
+                // is invalid.
+                Ok(checkpoint_height)
+                    if A::start_checkpoint(&self.list_template)
+                        .is_some_and(|start_checkpoint| checkpoint_height < start_checkpoint) =>
+                {
+                    tokio::time::sleep(self.config.ledger_tip_poll_interval).await;
+                    (Phase::Prologue(ProloguePhase::ReadInitialTip), None)
+                }
+                Ok(checkpoint_height) => {
+                    match build_initial_list_request::<A>(
+                        &self.list_template,
+                        checkpoint_height,
+                        self.config.list_page_limit,
+                    ) {
+                        Ok((payload, expected_end)) => (
+                            Phase::Prologue(ProloguePhase::Replay {
+                                list_machine: Box::new(ListMachine::new(
+                                    self.client.clone(),
+                                    payload,
+                                    expected_end,
+                                    ListScanDirection::Ascending,
+                                    LedgerTipPolicy::WaitForExpectedBound,
+                                    self.observability.clone(),
+                                    LedgerStreamStage::InitialReplay,
+                                )),
+                                target_checkpoint: checkpoint_height,
+                            }),
+                            None,
+                        ),
+                        Err(status) => (Phase::Terminal(status), None),
+                    }
+                }
+            },
+            ProloguePhase::Replay {
+                mut list_machine,
+                target_checkpoint,
+            } => {
+                let rpc_event = list_machine.poll_rpc().await;
+                let action = list_machine.process_event(rpc_event, &self.config);
+                let complete = matches!(&action, ListAction::Frame { complete: true, .. });
+                match self.process_replay_frame(action, target_checkpoint, ReplayOutput::Yield) {
+                    ReplayStep::Yield(output) => {
+                        let next = if complete {
+                            self.finish_prologue_replay(target_checkpoint)
+                        } else {
+                            Phase::Prologue(ProloguePhase::Replay {
+                                list_machine,
+                                target_checkpoint,
+                            })
+                        };
+                        (next, Some(output))
+                    }
+                    ReplayStep::Complete => (self.finish_prologue_replay(target_checkpoint), None),
+                    ReplayStep::Continue => (
+                        Phase::Prologue(ProloguePhase::Replay {
+                            list_machine,
+                            target_checkpoint,
+                        }),
+                        None,
+                    ),
+                    ReplayStep::Terminal(status) => (Phase::Terminal(status), None),
+                }
+            }
+        }
+    }
+
+    async fn step_subscribing(&mut self, phase: SubscribingPhase<A>) -> SubscribingStep<A> {
+        match phase {
+            SubscribingPhase::Connect(machine) => self.step_connect(machine).await,
+            SubscribingPhase::MuteUntilCommitted(mut live) => {
+                // This subscription began behind committed progress. Keep its frames hidden
+                // until it reaches that point; a later frame bounds the required List replay.
+                match live.stream.next().await {
+                    Some(Ok(response)) => match A::parse_live(response, self.item_required) {
+                        Err(status) => SubscribingStep::Terminal(status),
+                        Ok(frame) => match live
+                            .last_seen
+                            .classify_consecutive_subscription_progress(
+                                &frame.progress,
+                                frame.item.is_some(),
+                            ) {
+                            Err(status) => SubscribingStep::Terminal(status),
+                            Ok(ProgressAdvance::Unchanged) => {
+                                SubscribingStep::Next(SubscribingPhase::MuteUntilCommitted(live))
+                            }
+                            Ok(
+                                ProgressAdvance::CheckpointCoverageAdvanced
+                                | ProgressAdvance::CursorAdvanced,
+                            ) => {
+                                live.last_seen = frame.progress.clone();
+                                self.subscription_retry.reset(&self.observability);
+                                let Some(last_committed_progress) = self.committed_progress.clone()
+                                else {
+                                    return SubscribingStep::Terminal(Status::internal(
+                                        "muted subscription has no committed progress",
+                                    ));
+                                };
+                                match last_committed_progress.plan_recovery(
+                                    &frame.progress,
+                                    self.last_covered_checkpoint_height,
+                                ) {
+                                    Err(status) => SubscribingStep::Terminal(status),
+                                    Ok(Recovery::Live) => {
+                                        SubscribingStep::Next(SubscribingPhase::Live(live))
+                                    }
+                                    Ok(Recovery::MuteUntilCommitted) => SubscribingStep::Next(
+                                        SubscribingPhase::MuteUntilCommitted(live),
+                                    ),
+                                    Ok(Recovery::Replay(gap)) => {
+                                        self.enter_gap_replay(gap, live.stream, frame)
+                                    }
+                                }
+                            }
+                        },
+                    },
+                    Some(Err(status)) => {
+                        self.emit_subscription_interruption(
+                            &status,
+                            LedgerStreamStage::LiveSubscription,
+                        );
+                        self.schedule_connect_retry(
+                            status,
+                            FailurePhase::Body,
+                            LedgerStreamStage::LiveSubscription,
+                            ConnectContext::Resume,
+                        )
+                    }
+                    None => {
+                        let status = Status::unavailable("subscription stream ended unexpectedly");
+                        self.emit_subscription_interruption(
+                            &status,
+                            LedgerStreamStage::LiveSubscription,
+                        );
+                        self.schedule_connect_retry(
+                            status,
+                            FailurePhase::Body,
+                            LedgerStreamStage::LiveSubscription,
+                            ConnectContext::Resume,
+                        )
+                    }
+                }
+            }
+            SubscribingPhase::GapReplay(mut gap) => {
+                let rpc_event =
+                    if let BufferedSubscriptionState::Active(live) = &mut gap.subscription_state {
+                        tokio::select! {
+                            event = gap.list_machine.poll_rpc() => Some(event),
+                            result = live.stream.next() => {
+                                if gap.buffer_subscription_result(
+                                    result,
+                                    self.item_required,
+                                    &self.config,
+                                ) {
+                                    self.subscription_retry.reset(&self.observability);
+                                }
+                                None
+                            }
+                        }
+                    } else {
+                        Some(gap.list_machine.poll_rpc().await)
+                    };
+                let Some(rpc_event) = rpc_event else {
+                    return SubscribingStep::Next(SubscribingPhase::GapReplay(gap));
+                };
+                match gap.list_machine.process_event(rpc_event, &self.config) {
+                    ListAction::Frame {
+                        response,
+                        progress,
+                        complete,
+                    } => {
+                        let frame = match parse_replay_frame::<A>(response, progress) {
+                            Ok(frame) => frame,
+                            Err(status) => return SubscribingStep::Terminal(status),
+                        };
+                        let Some(progress) = frame.progress else {
+                            return SubscribingStep::Next(if complete {
+                                SubscribingPhase::DrainGapBuffer(
+                                    (*gap).into_buffered_subscription_drain(),
+                                )
+                            } else {
+                                SubscribingPhase::GapReplay(gap)
+                            });
+                        };
+                        if frame.item.is_none()
+                            && (gap.has_deferred_progress(&progress)
+                                || self.progress_is_committed(&progress))
+                        {
+                            return SubscribingStep::Next(if complete {
+                                SubscribingPhase::DrainGapBuffer(
+                                    (*gap).into_buffered_subscription_drain(),
+                                )
+                            } else {
+                                SubscribingPhase::GapReplay(gap)
+                            });
+                        }
+                        let mut item = frame.item;
+                        if item
+                            .as_ref()
+                            .is_some_and(|item| gap.replayed_item_was_already_emitted(item))
+                        {
+                            item = None;
+                        } else if let Some(item) = &item {
+                            gap.record_replayed_item(item);
+                        }
+                        self.commit_progress(progress.clone());
+                        let next = if complete {
+                            SubscribingPhase::DrainGapBuffer(
+                                (*gap).into_buffered_subscription_drain(),
+                            )
+                        } else {
+                            SubscribingPhase::GapReplay(gap)
+                        };
+                        SubscribingStep::Yield(next, self.make_output(item, progress))
+                    }
+                    ListAction::Continue => SubscribingStep::Next(SubscribingPhase::GapReplay(gap)),
+                    ListAction::Terminal(status) => SubscribingStep::Terminal(status),
+                }
+            }
+            SubscribingPhase::DrainGapBuffer(mut delivery) => {
+                if let Some(frame) = delivery.buffered_subscription_frames.pop_front() {
+                    let cursor_advanced = self
+                        .committed_progress
+                        .as_ref()
+                        .is_none_or(|committed| !committed.same_position(&frame.progress));
+                    let checkpoint_coverage_advanced = self
+                        .committed_progress
+                        .as_ref()
+                        .and_then(|committed| committed.checkpoint)
+                        .zip(frame.progress.checkpoint)
+                        .is_some_and(|(committed, next)| next > committed);
+                    let duplicate = frame.item.as_ref().is_some_and(|item| {
+                        delivery
+                            .replay_item_frontier
+                            .as_ref()
+                            .is_some_and(|frontier| A::item_position(item) <= frontier)
+                    });
+                    let item = if duplicate { None } else { frame.item };
+                    let next = SubscribingPhase::DrainGapBuffer(delivery);
+                    if duplicate {
+                        SubscribingStep::Next(next)
+                    } else {
+                        let yield_frame = item.is_some() || cursor_advanced;
+                        if yield_frame || checkpoint_coverage_advanced {
+                            self.commit_progress(frame.progress.clone());
+                        }
+                        if yield_frame {
+                            SubscribingStep::Yield(next, self.make_output(item, frame.progress))
+                        } else {
+                            SubscribingStep::Next(next)
+                        }
+                    }
+                } else {
+                    match delivery.subscription_state {
+                        BufferedSubscriptionState::Failed(status) => self.schedule_connect_retry(
+                            status,
+                            FailurePhase::Body,
+                            LedgerStreamStage::GapRecovery,
+                            ConnectContext::Resume,
+                        ),
+                        BufferedSubscriptionState::DroppedAtBufferLimit => {
+                            SubscribingStep::Next(SubscribingPhase::Connect(ConnectMachine {
+                                context: ConnectContext::Resume,
+                                phase: ConnectPhase::Attempt,
+                            }))
+                        }
+                        BufferedSubscriptionState::Active(live) => {
+                            SubscribingStep::Next(SubscribingPhase::Live(live))
+                        }
+                    }
+                }
+            }
+            SubscribingPhase::Live(mut live) => match live.stream.next().await {
+                Some(Ok(response)) => match A::parse_live(response, self.item_required) {
+                    Err(status) => SubscribingStep::Terminal(status),
+                    Ok(frame) => match live.last_seen.classify_consecutive_subscription_progress(
+                        &frame.progress,
+                        frame.item.is_some(),
+                    ) {
+                        Err(status) => SubscribingStep::Terminal(status),
+                        Ok(ProgressAdvance::Unchanged) => {
+                            SubscribingStep::Next(SubscribingPhase::Live(live))
+                        }
+                        Ok(ProgressAdvance::CheckpointCoverageAdvanced) => {
+                            live.last_seen = frame.progress.clone();
+                            self.commit_progress(frame.progress);
+                            self.subscription_retry.reset(&self.observability);
+                            SubscribingStep::Next(SubscribingPhase::Live(live))
+                        }
+                        Ok(ProgressAdvance::CursorAdvanced) => {
+                            let LiveFrame { item, progress } = frame;
+                            live.last_seen = progress.clone();
+                            self.commit_progress(progress.clone());
+                            self.subscription_retry.reset(&self.observability);
+                            SubscribingStep::Yield(
+                                SubscribingPhase::Live(live),
+                                self.make_output(item, progress),
+                            )
+                        }
+                    },
+                },
+                Some(Err(status)) => {
+                    self.emit_subscription_interruption(
+                        &status,
+                        LedgerStreamStage::LiveSubscription,
+                    );
+                    self.schedule_connect_retry(
+                        status,
+                        FailurePhase::Body,
+                        LedgerStreamStage::LiveSubscription,
+                        ConnectContext::Resume,
+                    )
+                }
+                None => {
+                    let status = Status::unavailable("subscription stream ended unexpectedly");
+                    self.emit_subscription_interruption(
+                        &status,
+                        LedgerStreamStage::LiveSubscription,
+                    );
+                    self.schedule_connect_retry(
+                        status,
+                        FailurePhase::Body,
+                        LedgerStreamStage::LiveSubscription,
+                        ConnectContext::Resume,
+                    )
+                }
+            },
+        }
+    }
+
+    async fn step_polling(&mut self, phase: PollingPhase<A>) -> PollingStep<A> {
+        match phase {
+            PollingPhase::ReadBaselineTip => match self
+                .read_service_checkpoint_height(LedgerStreamStage::PollingBaseline)
+                .await
+            {
+                Err(status) => PollingStep::Terminal(status),
+                Ok(checkpoint_height) => {
+                    match build_live_tip_baseline_list_request::<A>(
+                        &self.list_template,
+                        checkpoint_height,
+                        self.config.list_page_limit,
+                    ) {
+                        Ok((payload, expected_end)) => PollingStep::Next(PollingPhase::Replay {
+                            list_machine: Box::new(ListMachine::new(
+                                self.client.clone(),
+                                payload,
+                                expected_end,
+                                ListScanDirection::Ascending,
+                                LedgerTipPolicy::WaitForExpectedBound,
+                                self.observability.clone(),
+                                LedgerStreamStage::PollingBaseline,
+                            )),
+                            target_checkpoint: checkpoint_height,
+                            output: ReplayOutput::Suppress,
+                        }),
+                        Err(status) => PollingStep::Terminal(status),
+                    }
+                }
+            },
+            PollingPhase::Replay {
+                mut list_machine,
+                target_checkpoint,
+                output,
+            } => {
+                let rpc_event = list_machine.poll_rpc().await;
+                let action = list_machine.process_event(rpc_event, &self.config);
+                let complete = matches!(&action, ListAction::Frame { complete: true, .. });
+                match self.process_replay_frame(action, target_checkpoint, output) {
+                    ReplayStep::Yield(frame_output) => {
+                        if complete {
+                            match self.finish_polling_replay(target_checkpoint) {
+                                Ok(next) => PollingStep::Yield(next, frame_output),
+                                Err(status) => PollingStep::Terminal(status),
+                            }
+                        } else {
+                            PollingStep::Yield(
+                                PollingPhase::Replay {
+                                    list_machine,
+                                    target_checkpoint,
+                                    output,
+                                },
+                                frame_output,
+                            )
+                        }
+                    }
+                    ReplayStep::Complete => match self.finish_polling_replay(target_checkpoint) {
+                        Ok(next) => PollingStep::Next(next),
+                        Err(status) => PollingStep::Terminal(status),
+                    },
+                    ReplayStep::Continue if complete => {
+                        match self.finish_polling_replay(target_checkpoint) {
+                            Ok(next) => PollingStep::Next(next),
+                            Err(status) => PollingStep::Terminal(status),
+                        }
+                    }
+                    ReplayStep::Continue => PollingStep::Next(PollingPhase::Replay {
+                        list_machine,
+                        target_checkpoint,
+                        output,
+                    }),
+                    ReplayStep::Terminal(status) => PollingStep::Terminal(status),
+                }
+            }
+            PollingPhase::Sleep => {
+                tokio::time::sleep(self.config.ledger_tip_poll_interval).await;
+                PollingStep::Next(PollingPhase::ReadTip)
+            }
+            PollingPhase::ReadTip => match self
+                .read_service_checkpoint_height(LedgerStreamStage::PollingTail)
+                .await
+            {
+                Err(status) => PollingStep::Terminal(status),
+                Ok(checkpoint_height)
+                    if self
+                        .last_covered_checkpoint_height
+                        .is_some_and(|covered| checkpoint_height <= covered) =>
+                {
+                    PollingStep::Next(PollingPhase::Sleep)
+                }
+                Ok(checkpoint_height) => {
+                    let Some(committed_progress) = self.committed_progress.as_ref() else {
+                        return PollingStep::Terminal(Status::data_loss(
+                            "subscription recovery has no committed progress marker",
+                        ));
+                    };
+                    match build_polling_list_request::<A>(
+                        &self.list_template,
+                        committed_progress,
+                        checkpoint_height,
+                        self.config.list_page_limit,
+                    ) {
+                        Ok((payload, expected_end)) => PollingStep::Next(PollingPhase::Replay {
+                            list_machine: Box::new(ListMachine::new(
+                                self.client.clone(),
+                                payload,
+                                expected_end,
+                                ListScanDirection::Ascending,
+                                LedgerTipPolicy::WaitForExpectedBound,
+                                self.observability.clone(),
+                                LedgerStreamStage::PollingTail,
+                            )),
+                            target_checkpoint: checkpoint_height,
+                            output: ReplayOutput::Yield,
+                        }),
+                        Err(status) => PollingStep::Terminal(status),
+                    }
+                }
+            },
+        }
+    }
+
+    async fn read_service_checkpoint_height(
+        &mut self,
+        observability_stage: LedgerStreamStage,
+    ) -> Result<u64> {
+        loop {
+            let request = Request::new(GetServiceInfoRequest::default());
+            let mut client = self.client.ledger_client();
+            let future = client.get_service_info(request);
+            let started_at = self.observability.start_timer();
+            let result = future.await;
+            self.observability.emit_rpc_response(
+                started_at,
+                A::FAMILY,
+                LedgerStreamOperation::GetServiceInfo,
+                observability_stage,
+                &result,
+            );
+            match result {
+                Ok(response) => {
+                    let checkpoint_height =
+                        response.into_inner().checkpoint_height.ok_or_else(|| {
+                            Status::data_loss(
+                                "GetServiceInfo response is missing checkpoint_height",
+                            )
+                        })?;
+                    self.service_info_retry.reset(&self.observability);
+                    return Ok(checkpoint_height);
+                }
+                Err(status) => {
+                    let Some(delay) = self.service_info_retry.retry_delay(
+                        &status,
+                        // Unary dispatch and body share this await. Remote statuses retain dispatch
+                        // classification; local tonic transport sources allow reset-code retry.
+                        FailurePhase::Dispatch,
+                        &self.config,
+                        &self.observability,
+                        observability_stage,
+                    ) else {
+                        return Err(status);
+                    };
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    fn emit_subscription_interruption(
+        &self,
+        status: &Status,
+        observability_stage: LedgerStreamStage,
+    ) {
+        self.observability
+            .emit(|| LedgerStreamEvent::SubscriptionStreamInterrupted {
+                family: A::FAMILY,
+                stage: observability_stage,
+                status: status.clone(),
+            });
+    }
+
+    fn process_replay_frame(
+        &mut self,
+        action: ListAction<A::ListResponse, Progress<A::Cursor>>,
+        target_checkpoint: u64,
+        output: ReplayOutput,
+    ) -> ReplayStep<A> {
+        match action {
+            ListAction::Frame {
+                response,
+                progress,
+                complete,
+            } => {
+                let frame = match parse_replay_frame::<A>(response, progress) {
+                    Ok(frame) => frame,
+                    Err(status) => return ReplayStep::Terminal(status),
+                };
+                let Some(progress) = frame.progress else {
+                    if !complete {
+                        return ReplayStep::Continue;
+                    }
+                    let Some(cursor) = frame.watermark.cursor else {
+                        return ReplayStep::Terminal(Status::data_loss(
+                            "subscription recovery has no committed progress marker",
+                        ));
+                    };
+                    let Some(progress) = A::Cursor::position(&cursor, Some(target_checkpoint))
+                    else {
+                        return ReplayStep::Terminal(Status::internal(
+                            "checkpoint-bound watermark names no position",
+                        ));
+                    };
+                    let duplicate = self.progress_is_committed(&progress);
+                    self.commit_progress(progress.clone());
+                    return if duplicate || matches!(output, ReplayOutput::Suppress) {
+                        ReplayStep::Complete
+                    } else {
+                        ReplayStep::Yield(self.make_output(None, progress))
+                    };
+                };
+                let duplicate = frame.item.is_none() && self.progress_is_committed(&progress);
+                self.commit_progress(progress.clone());
+                if duplicate || matches!(output, ReplayOutput::Suppress) {
+                    self.commit_item_position(&frame.item);
+                    if complete {
+                        ReplayStep::Complete
+                    } else {
+                        ReplayStep::Continue
+                    }
+                } else {
+                    ReplayStep::Yield(self.make_output(frame.item, progress))
+                }
+            }
+            ListAction::Continue => ReplayStep::Continue,
+            ListAction::Terminal(status) => ReplayStep::Terminal(status),
+        }
+    }
+
+    fn finish_prologue_replay(&mut self, target_checkpoint: u64) -> Phase<A> {
+        self.last_covered_checkpoint_height = Some(
+            self.last_covered_checkpoint_height
+                .map_or(target_checkpoint, |covered| covered.max(target_checkpoint)),
+        );
+        if self.committed_progress.is_none() {
+            return Phase::Terminal(Status::data_loss(
+                "subscription recovery has no committed progress marker",
+            ));
+        }
+        match self.delivery {
+            Delivery::Subscribe => Phase::Subscribing(SubscribingPhase::Connect(ConnectMachine {
+                context: ConnectContext::Resume,
+                phase: ConnectPhase::Attempt,
+            })),
+            Delivery::Poll => Phase::Polling(PollingPhase::Sleep),
+        }
+    }
+
+    fn finish_polling_replay(&mut self, target_checkpoint: u64) -> Result<PollingPhase<A>> {
+        self.last_covered_checkpoint_height = Some(
+            self.last_covered_checkpoint_height
+                .map_or(target_checkpoint, |covered| covered.max(target_checkpoint)),
+        );
+        if self.committed_progress.is_none() {
+            return Err(Status::data_loss(
+                "subscription recovery has no committed progress marker",
+            ));
+        }
+        Ok(PollingPhase::Sleep)
+    }
+
+    fn finish_subscription_recovery_replay(&mut self, target_checkpoint: u64) -> ConnectMachine<A> {
+        self.last_covered_checkpoint_height = Some(
+            self.last_covered_checkpoint_height
+                .map_or(target_checkpoint, |covered| covered.max(target_checkpoint)),
+        );
+        ConnectMachine {
+            context: ConnectContext::Resume,
+            phase: ConnectPhase::Attempt,
+        }
+    }
+
+    fn enter_gap_replay(
+        &mut self,
+        gap: RecoveryGap,
+        new_subscription_stream: BoxStream<A::SubscribeResponse>,
+        new_subscription_frame: LiveFrame<A::Item, Progress<A::Cursor>>,
+    ) -> SubscribingStep<A> {
+        // List fills the interval through this frame before buffered live data is delivered.
+        let recovery_list_template = A::list_request_from_subscribe(&self.subscribe_payload);
+        let (payload, expected_end) = match build_recovery_list_request::<A>(
+            recovery_list_template,
+            &gap,
+            self.config.list_page_limit,
+        ) {
+            Ok(request) => request,
+            Err(status) => return SubscribingStep::Terminal(status),
+        };
+        self.observability
+            .emit(|| LedgerStreamEvent::GapRecoveryStarted { family: A::FAMILY });
+        let new_live_subscription = LiveSubscription {
+            stream: new_subscription_stream,
+            last_seen: new_subscription_frame.progress.clone(),
+        };
+        let recovery_list_machine = ListMachine::new(
+            self.client.clone(),
+            payload,
+            expected_end,
+            ListScanDirection::Ascending,
+            LedgerTipPolicy::WaitForExpectedBound,
+            self.observability.clone(),
+            LedgerStreamStage::GapRecovery,
+        );
+        SubscribingStep::Next(SubscribingPhase::GapReplay(Box::new(GapReplay::new(
+            recovery_list_machine,
+            new_live_subscription,
+            new_subscription_frame,
+            self.committed_item_position.clone(),
+            &self.config,
+            gap.replays_boundary_item(),
+        ))))
+    }
+
+    async fn step_connect(&mut self, machine: ConnectMachine<A>) -> SubscribingStep<A> {
+        let ConnectMachine { context, phase } = machine;
+        match phase {
+            ConnectPhase::Attempt => {
+                let observability_stage = match context {
+                    ConnectContext::LiveTipStartup => LedgerStreamStage::LiveTipStartup,
+                    ConnectContext::Resume => LedgerStreamStage::LiveSubscription,
+                };
+                match self.subscription_attempt(observability_stage).await {
+                    Err(status) => SubscribingStep::Terminal(status),
+                    Ok(SubscriptionAttempt::Failed {
+                        status,
+                        failure_phase,
+                    }) => self.schedule_connect_retry(
+                        status,
+                        failure_phase,
+                        observability_stage,
+                        context,
+                    ),
+                    Ok(SubscriptionAttempt::Established {
+                        stream,
+                        first_frame,
+                    }) => {
+                        self.subscription_retry.reset(&self.observability);
+                        match context {
+                            ConnectContext::LiveTipStartup => {
+                                let LiveFrame { item, progress } = first_frame;
+                                let live = LiveSubscription {
+                                    stream,
+                                    last_seen: progress.clone(),
+                                };
+                                self.commit_progress(progress.clone());
+                                SubscribingStep::Yield(
+                                    SubscribingPhase::Live(live),
+                                    self.make_output(item, progress),
+                                )
+                            }
+                            ConnectContext::Resume => {
+                                let Some(last_committed_progress) = self.committed_progress.clone()
+                                else {
+                                    return SubscribingStep::Terminal(Status::data_loss(
+                                        "subscription recovery has no committed progress marker",
+                                    ));
+                                };
+                                match last_committed_progress.plan_recovery(
+                                    &first_frame.progress,
+                                    self.last_covered_checkpoint_height,
+                                ) {
+                                    Err(status) => SubscribingStep::Terminal(status),
+                                    Ok(Recovery::Live) => SubscribingStep::Next(
+                                        SubscribingPhase::Live(LiveSubscription {
+                                            stream,
+                                            last_seen: first_frame.progress,
+                                        }),
+                                    ),
+                                    Ok(Recovery::MuteUntilCommitted) => SubscribingStep::Next(
+                                        SubscribingPhase::MuteUntilCommitted(LiveSubscription {
+                                            stream,
+                                            last_seen: first_frame.progress,
+                                        }),
+                                    ),
+                                    Ok(Recovery::Replay(gap)) => {
+                                        self.enter_gap_replay(gap, stream, first_frame)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            ConnectPhase::RetryDelay { delay } => {
+                tokio::time::sleep(delay).await;
+                SubscribingStep::Next(SubscribingPhase::Connect(ConnectMachine {
+                    context,
+                    phase: ConnectPhase::ReadRecoveryTip,
+                }))
+            }
+            ConnectPhase::ReadRecoveryTip => {
+                let committed_progress = self.committed_progress.clone();
+                match self
+                    .read_service_checkpoint_height(LedgerStreamStage::GapRecovery)
+                    .await
+                {
+                    Err(status) => SubscribingStep::Terminal(status),
+                    Ok(checkpoint_height)
+                        if committed_progress
+                            .as_ref()
+                            .and_then(|progress| progress.checkpoint)
+                            .is_some_and(|committed| checkpoint_height <= committed) =>
+                    {
+                        SubscribingStep::Next(SubscribingPhase::Connect(ConnectMachine {
+                            context: ConnectContext::Resume,
+                            phase: ConnectPhase::Attempt,
+                        }))
+                    }
+                    Ok(checkpoint_height) => {
+                        let (request, output) =
+                            if let Some(committed_progress) = &committed_progress {
+                                (
+                                    build_polling_list_request::<A>(
+                                        &self.list_template,
+                                        committed_progress,
+                                        checkpoint_height,
+                                        self.config.list_page_limit,
+                                    ),
+                                    ReplayOutput::Yield,
+                                )
+                            } else {
+                                (
+                                    build_live_tip_baseline_list_request::<A>(
+                                        &self.list_template,
+                                        checkpoint_height,
+                                        self.config.list_page_limit,
+                                    ),
+                                    ReplayOutput::Suppress,
+                                )
+                            };
+                        match request {
+                            Err(status) => SubscribingStep::Terminal(status),
+                            Ok((payload, expected_end)) => {
+                                self.observability
+                                    .emit(|| LedgerStreamEvent::GapRecoveryStarted {
+                                        family: A::FAMILY,
+                                    });
+                                SubscribingStep::Next(SubscribingPhase::Connect(ConnectMachine {
+                                    context,
+                                    phase: ConnectPhase::ReplayToRecoveryTip {
+                                        list_machine: Box::new(ListMachine::new(
+                                            self.client.clone(),
+                                            payload,
+                                            expected_end,
+                                            ListScanDirection::Ascending,
+                                            LedgerTipPolicy::WaitForExpectedBound,
+                                            self.observability.clone(),
+                                            LedgerStreamStage::GapRecovery,
+                                        )),
+                                        target_checkpoint: checkpoint_height,
+                                        output,
+                                    },
+                                }))
+                            }
+                        }
+                    }
+                }
+            }
+            ConnectPhase::ReplayToRecoveryTip {
+                mut list_machine,
+                target_checkpoint,
+                output,
+            } => {
+                let rpc_event = list_machine.poll_rpc().await;
+                let action = list_machine.process_event(rpc_event, &self.config);
+                let complete = matches!(&action, ListAction::Frame { complete: true, .. });
+                match self.process_replay_frame(action, target_checkpoint, output) {
+                    ReplayStep::Yield(frame_output) => {
+                        let next = if complete {
+                            self.finish_subscription_recovery_replay(target_checkpoint)
+                        } else {
+                            ConnectMachine {
+                                context,
+                                phase: ConnectPhase::ReplayToRecoveryTip {
+                                    list_machine,
+                                    target_checkpoint,
+                                    output,
+                                },
+                            }
+                        };
+                        SubscribingStep::Yield(SubscribingPhase::Connect(next), frame_output)
+                    }
+                    ReplayStep::Complete => SubscribingStep::Next(SubscribingPhase::Connect(
+                        self.finish_subscription_recovery_replay(target_checkpoint),
+                    )),
+                    ReplayStep::Continue if complete => {
+                        SubscribingStep::Next(SubscribingPhase::Connect(
+                            self.finish_subscription_recovery_replay(target_checkpoint),
+                        ))
+                    }
+                    ReplayStep::Continue => {
+                        SubscribingStep::Next(SubscribingPhase::Connect(ConnectMachine {
+                            context,
+                            phase: ConnectPhase::ReplayToRecoveryTip {
+                                list_machine,
+                                target_checkpoint,
+                                output,
+                            },
+                        }))
+                    }
+                    ReplayStep::Terminal(status) => SubscribingStep::Terminal(status),
+                }
+            }
+        }
+    }
+
+    async fn subscription_attempt(
+        &mut self,
+        observability_stage: LedgerStreamStage,
+    ) -> Result<SubscriptionAttempt<A>> {
+        let request = Request::new(self.subscribe_payload.clone());
+        let mut stream = match dispatch_subscription::<A>(
+            &self.client,
+            &self.observability,
+            request,
+            observability_stage,
+        )
+        .await
+        {
+            Ok(stream) => stream,
+            Err(status) => {
+                return Ok(SubscriptionAttempt::Failed {
+                    status,
+                    failure_phase: FailurePhase::Dispatch,
+                });
+            }
+        };
+        let first_frame = match stream.next().await {
+            Some(Ok(response)) => A::parse_live(response, self.item_required)?,
+            Some(Err(status)) => {
+                self.emit_subscription_interruption(&status, observability_stage);
+                return Ok(SubscriptionAttempt::Failed {
+                    status,
+                    failure_phase: FailurePhase::Body,
+                });
+            }
+            None => {
+                let status = Status::unavailable("subscription stream ended unexpectedly");
+                self.emit_subscription_interruption(&status, observability_stage);
+                return Ok(SubscriptionAttempt::Failed {
+                    status,
+                    failure_phase: FailurePhase::Body,
+                });
+            }
+        };
+        if !first_frame.progress.has_checkpoint_coverage() {
+            return Err(Status::data_loss(
+                "subscription initial frame is missing checkpoint coverage",
+            ));
+        }
+        Ok(SubscriptionAttempt::Established {
+            stream,
+            first_frame,
+        })
+    }
+
+    fn schedule_connect_retry(
+        &mut self,
+        status: Status,
+        failure_phase: FailurePhase,
+        observability_stage: LedgerStreamStage,
+        context: ConnectContext,
+    ) -> SubscribingStep<A> {
+        let Some(delay) = self.subscription_retry.retry_delay(
+            &status,
+            failure_phase,
+            &self.config,
+            &self.observability,
+            observability_stage,
+        ) else {
+            return SubscribingStep::Terminal(status);
+        };
+        SubscribingStep::Next(SubscribingPhase::Connect(ConnectMachine {
+            context,
+            phase: ConnectPhase::RetryDelay { delay },
+        }))
+    }
+
+    fn progress_is_committed(&self, progress: &Progress<A::Cursor>) -> bool {
+        self.committed_progress
+            .as_ref()
+            .is_some_and(|committed| committed.same_position(progress))
+            || self.committed_progress.is_none()
+                && A::request_resume_position(&self.list_template)
+                    .as_ref()
+                    .is_some_and(|resume| resume.same_position(progress))
+    }
+
+    fn commit_item_position(&mut self, item: &Option<A::Item>) {
+        if let Some(item) = item {
+            self.committed_item_position = Some(A::item_position(item).clone());
+        }
+    }
+
+    fn make_output(&mut self, item: Option<A::Item>, progress: Progress<A::Cursor>) -> A::Output {
+        self.commit_item_position(&item);
+        A::into_output(item, progress)
+    }
+
+    fn commit_progress(&mut self, mut progress: Progress<A::Cursor>) {
+        if let Some(committed) = &self.committed_progress {
+            // Preserve known checkpoint coverage when a later watermark omits it.
+            progress.inherit_checkpoint_coverage(committed);
+        }
+        self.committed_progress = Some(progress);
+    }
+}

--- a/crates/sui-rpc/src/client/ledger_streams/subscription.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/subscription.rs
@@ -1,0 +1,195 @@
+use std::collections::VecDeque;
+
+use tonic::Status;
+use tonic::codegen::BoxStream;
+
+use super::super::Result;
+use super::adapter::LiveFrame;
+use super::adapter::Progress;
+use super::adapter::ProgressAdvance;
+use super::adapter::SubscriptionAdapter;
+use super::list::ListMachine;
+use super::observability::LedgerStreamEvent;
+use super::observability::LedgerStreamObservability;
+use super::observability::LedgerStreamStage;
+use super::types::LedgerStreamConfig;
+
+pub(super) struct LiveSubscription<A: SubscriptionAdapter> {
+    pub(super) stream: BoxStream<A::SubscribeResponse>,
+    pub(super) last_seen: Progress<A::Cursor>,
+}
+
+pub(super) enum BufferedSubscriptionState<A: SubscriptionAdapter> {
+    Active(LiveSubscription<A>),
+    Failed(Status),
+    DroppedAtBufferLimit,
+}
+
+pub(super) struct GapReplay<A: SubscriptionAdapter> {
+    pub(super) list_machine: ListMachine<A>,
+    pub(super) subscription_state: BufferedSubscriptionState<A>,
+    /// Item frames retain payloads; adjacent progress-only frames coalesce once per contiguous run.
+    buffered_subscription_frames: VecDeque<LiveFrame<A::Item, Progress<A::Cursor>>>,
+    /// Number of payload-bearing frames currently buffered, bounded by `max_buffered_live_items`
+    /// (empty progress-only frames do not count toward this limit).
+    buffered_subscription_items: usize,
+    replay_item_frontier: Option<A::ItemPosition>,
+    observability: LedgerStreamObservability,
+}
+
+impl<A: SubscriptionAdapter> GapReplay<A> {
+    pub(super) fn new(
+        list_machine: ListMachine<A>,
+        live: LiveSubscription<A>,
+        first: LiveFrame<A::Item, Progress<A::Cursor>>,
+        committed_item_position: Option<A::ItemPosition>,
+        config: &LedgerStreamConfig,
+        replays_boundary_item: bool,
+    ) -> Self {
+        let observability = list_machine.observability.clone();
+        let mut gap = Self {
+            list_machine,
+            subscription_state: BufferedSubscriptionState::Active(live),
+            buffered_subscription_frames: VecDeque::new(),
+            buffered_subscription_items: 0,
+            observability,
+            replay_item_frontier: committed_item_position,
+        };
+        if !replays_boundary_item {
+            gap.retain_frame(first, Some(config));
+        }
+        gap
+    }
+
+    fn retain_frame(
+        &mut self,
+        frame: LiveFrame<A::Item, Progress<A::Cursor>>,
+        config: Option<&LedgerStreamConfig>,
+    ) {
+        if frame.item.is_none()
+            && let Some(deferred_tail) = self.buffered_subscription_frames.back_mut()
+            && deferred_tail.item.is_none()
+        {
+            deferred_tail.progress = frame.progress;
+            return;
+        }
+
+        if frame.item.is_some() {
+            self.buffered_subscription_items = self.buffered_subscription_items.saturating_add(1);
+        }
+        self.buffered_subscription_frames.push_back(frame);
+        if let Some(config) = config
+            && self.buffered_subscription_items >= config.max_buffered_live_items.get()
+            && matches!(
+                &self.subscription_state,
+                BufferedSubscriptionState::Active(_)
+            )
+        {
+            self.subscription_state = BufferedSubscriptionState::DroppedAtBufferLimit;
+            let buffered_items = self.buffered_subscription_items;
+            let limit = config.max_buffered_live_items.get();
+            self.observability
+                .emit(|| LedgerStreamEvent::SubscriptionBufferLimitReached {
+                    family: A::FAMILY,
+                    buffered_items,
+                    limit,
+                });
+        }
+    }
+
+    pub(super) fn has_deferred_progress(&self, progress: &Progress<A::Cursor>) -> bool {
+        self.buffered_subscription_frames
+            .iter()
+            .any(|frame| frame.progress.same_position(progress))
+    }
+
+    pub(super) fn replayed_item_was_already_emitted(&self, item: &A::Item) -> bool {
+        self.replay_item_frontier
+            .as_ref()
+            .is_some_and(|frontier| A::item_position(item) <= frontier)
+    }
+
+    pub(super) fn record_replayed_item(&mut self, item: &A::Item) {
+        let position = A::item_position(item);
+        if self
+            .replay_item_frontier
+            .as_ref()
+            .is_none_or(|frontier| position > frontier)
+        {
+            self.replay_item_frontier = Some(position.clone());
+        }
+    }
+
+    /// Returns whether a valid buffered frame advanced subscription progress, controlling retry
+    /// backoff reset.
+    pub(super) fn buffer_subscription_result(
+        &mut self,
+        result: Option<Result<A::SubscribeResponse>>,
+        item_required: bool,
+        config: &LedgerStreamConfig,
+    ) -> bool {
+        let BufferedSubscriptionState::Active(live) = &mut self.subscription_state else {
+            return false;
+        };
+        let frame = match result {
+            Some(Ok(response)) => match A::parse_live(response, item_required) {
+                Ok(frame) => frame,
+                Err(status) => {
+                    self.subscription_state = BufferedSubscriptionState::Failed(status);
+                    return false;
+                }
+            },
+            Some(Err(status)) => {
+                self.observability
+                    .emit(|| LedgerStreamEvent::SubscriptionStreamInterrupted {
+                        family: A::FAMILY,
+                        stage: LedgerStreamStage::GapRecovery,
+                        status: status.clone(),
+                    });
+                self.subscription_state = BufferedSubscriptionState::Failed(status);
+                return false;
+            }
+            None => {
+                let status = Status::unavailable("subscription stream ended unexpectedly");
+                self.observability
+                    .emit(|| LedgerStreamEvent::SubscriptionStreamInterrupted {
+                        family: A::FAMILY,
+                        stage: LedgerStreamStage::GapRecovery,
+                        status: status.clone(),
+                    });
+                self.subscription_state = BufferedSubscriptionState::Failed(status);
+                return false;
+            }
+        };
+
+        match live
+            .last_seen
+            .classify_consecutive_subscription_progress(&frame.progress, frame.item.is_some())
+        {
+            Err(status) => {
+                self.subscription_state = BufferedSubscriptionState::Failed(status);
+                false
+            }
+            Ok(ProgressAdvance::Unchanged) => false,
+            Ok(ProgressAdvance::CheckpointCoverageAdvanced | ProgressAdvance::CursorAdvanced) => {
+                live.last_seen = frame.progress.clone();
+                self.retain_frame(frame, Some(config));
+                true
+            }
+        }
+    }
+
+    pub(super) fn into_buffered_subscription_drain(self) -> BufferedSubscriptionDrain<A> {
+        BufferedSubscriptionDrain {
+            subscription_state: self.subscription_state,
+            buffered_subscription_frames: self.buffered_subscription_frames,
+            replay_item_frontier: self.replay_item_frontier,
+        }
+    }
+}
+
+pub(super) struct BufferedSubscriptionDrain<A: SubscriptionAdapter> {
+    pub(super) subscription_state: BufferedSubscriptionState<A>,
+    pub(super) buffered_subscription_frames: VecDeque<LiveFrame<A::Item, Progress<A::Cursor>>>,
+    pub(super) replay_item_frontier: Option<A::ItemPosition>,
+}

--- a/crates/sui-rpc/src/client/ledger_streams/types.rs
+++ b/crates/sui-rpc/src/client/ledger_streams/types.rs
@@ -1,0 +1,376 @@
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::observability::LedgerStreamEvent;
+use super::observability::LedgerStreamObserver;
+use super::observability::ListEvent;
+use super::observability::ListObserver;
+use crate::proto::sui::rpc::v2::Checkpoint;
+use crate::proto::sui::rpc::v2::Event;
+use crate::proto::sui::rpc::v2::EventFilter;
+use crate::proto::sui::rpc::v2::ExecutedTransaction;
+use crate::proto::sui::rpc::v2::TransactionFilter;
+use prost::bytes::Bytes;
+use prost_types::FieldMask;
+/// How a stream follows the ledger.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Delivery {
+    /// Follows the tip through SubscriptionService, repairing gaps through List.
+    #[default]
+    Subscribe,
+    /// Follows the ledger via the List APIs, useful on endpoints without SubscriptionService.
+    Poll,
+}
+
+/// Starting position for a checkpoint stream.
+#[non_exhaustive]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum CheckpointStreamStart {
+    /// Begins at the chain tip (live for `Subscribe`, indexed for `Poll`) and emits an initial
+    /// progress frame before subsequent items.
+    #[default]
+    Tip,
+    /// Starts at and includes the checkpoint with this sequence number.
+    Checkpoint(u64),
+}
+
+/// Starting position for a transaction stream.
+#[non_exhaustive]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum TransactionStreamStart {
+    /// Begins at the chain tip (live for `Subscribe`, indexed for `Poll`) and emits an initial
+    /// progress frame before subsequent items.
+    #[default]
+    Tip,
+    /// Starts at and includes transactions from this checkpoint.
+    Checkpoint(u64),
+    /// Starts strictly after this server-validated opaque cursor.
+    Resume(Bytes),
+}
+
+/// Starting position for an event stream.
+#[non_exhaustive]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum EventStreamStart {
+    /// Begins at the chain tip (live for `Subscribe`, indexed for `Poll`) and emits an initial
+    /// progress frame before subsequent items.
+    #[default]
+    Tip,
+    /// Starts at and includes events from this checkpoint.
+    Checkpoint(u64),
+    /// Starts strictly after this server-validated opaque cursor.
+    Resume(Bytes),
+}
+
+/// Request for a resumable checkpoint stream.
+#[non_exhaustive]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CheckpointStreamRequest {
+    /// Projection applied to both List and Subscribe requests.
+    pub read_mask: Option<FieldMask>,
+    /// Transaction filter applied to checkpoints.
+    pub filter: Option<TransactionFilter>,
+    /// Logical starting position.
+    pub start: CheckpointStreamStart,
+    /// How the stream follows the ledger.
+    pub delivery: Delivery,
+}
+
+impl CheckpointStreamRequest {
+    /// Creates a request with the default start and delivery.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the response projection.
+    pub fn with_read_mask(mut self, read_mask: impl Into<FieldMask>) -> Self {
+        self.read_mask = Some(read_mask.into());
+        self
+    }
+
+    /// Sets the transaction filter.
+    pub fn with_filter(mut self, filter: impl Into<TransactionFilter>) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    /// Sets the logical starting position.
+    pub fn with_start(mut self, start: impl Into<CheckpointStreamStart>) -> Self {
+        self.start = start.into();
+        self
+    }
+
+    /// Sets how the stream follows the ledger.
+    pub fn with_delivery(mut self, delivery: impl Into<Delivery>) -> Self {
+        self.delivery = delivery.into();
+        self
+    }
+}
+
+/// Request for a resumable transaction stream.
+#[non_exhaustive]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct TransactionStreamRequest {
+    /// Projection applied to both List and Subscribe requests.
+    pub read_mask: Option<FieldMask>,
+    /// Filter applied to transactions.
+    pub filter: Option<TransactionFilter>,
+    /// Logical starting position.
+    pub start: TransactionStreamStart,
+    /// How the stream follows the ledger.
+    pub delivery: Delivery,
+}
+
+impl TransactionStreamRequest {
+    /// Creates a request with the default start and delivery.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the response projection.
+    pub fn with_read_mask(mut self, read_mask: impl Into<FieldMask>) -> Self {
+        self.read_mask = Some(read_mask.into());
+        self
+    }
+
+    /// Sets the transaction filter.
+    pub fn with_filter(mut self, filter: impl Into<TransactionFilter>) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    /// Sets the logical starting position.
+    pub fn with_start(mut self, start: impl Into<TransactionStreamStart>) -> Self {
+        self.start = start.into();
+        self
+    }
+
+    /// Sets how the stream follows the ledger.
+    pub fn with_delivery(mut self, delivery: impl Into<Delivery>) -> Self {
+        self.delivery = delivery.into();
+        self
+    }
+}
+
+/// Request for a resumable event stream.
+#[non_exhaustive]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct EventStreamRequest {
+    /// Projection applied to both List and Subscribe requests.
+    pub read_mask: Option<FieldMask>,
+    /// Filter applied to events.
+    pub filter: Option<EventFilter>,
+    /// Logical starting position.
+    pub start: EventStreamStart,
+    /// How the stream follows the ledger.
+    pub delivery: Delivery,
+}
+
+impl EventStreamRequest {
+    /// Creates a request with the default start and delivery.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the response projection.
+    pub fn with_read_mask(mut self, read_mask: impl Into<FieldMask>) -> Self {
+        self.read_mask = Some(read_mask.into());
+        self
+    }
+
+    /// Sets the event filter.
+    pub fn with_filter(mut self, filter: impl Into<EventFilter>) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    /// Sets the logical starting position.
+    pub fn with_start(mut self, start: impl Into<EventStreamStart>) -> Self {
+        self.start = start.into();
+        self
+    }
+
+    /// Sets how the stream follows the ledger.
+    pub fn with_delivery(mut self, delivery: impl Into<Delivery>) -> Self {
+        self.delivery = delivery.into();
+        self
+    }
+}
+
+/// A checkpoint frame with an optional payload and inclusive restart cursor.
+///
+/// Process `checkpoint` before persisting `cursor`. To resume after this checkpoint,
+/// start the next stream from `CheckpointStreamStart::Checkpoint(cursor + 1)`.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct CheckpointStreamFrame {
+    /// The checkpoint payload, or `None` for a progress-only frame.
+    pub checkpoint: Option<Checkpoint>,
+    /// The inclusive checkpoint cursor represented by this frame.
+    pub cursor: u64,
+}
+
+/// A transaction frame with an optional payload and opaque exclusive restart cursor.
+///
+/// Process `transaction` before persisting `cursor`, then resume with
+/// `TransactionStreamStart::Resume(cursor)`.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct TransactionStreamFrame {
+    /// The executed transaction payload, or `None` for a progress-only frame.
+    pub transaction: Option<ExecutedTransaction>,
+    /// The server's opaque resume cursor as of this frame, passed through verbatim.
+    pub cursor: Bytes,
+    /// Checkpoint coverage reported with this frame, when known, for progress observability.
+    pub covered_checkpoint: Option<u64>,
+}
+
+/// An event frame with an optional payload and opaque exclusive restart cursor.
+///
+/// Process `event` before persisting `cursor`, then resume with `EventStreamStart::Resume(cursor)`.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct EventStreamFrame {
+    /// The event payload, or `None` for a progress-only frame.
+    pub event: Option<Event>,
+    /// The server's opaque resume cursor as of this frame, passed through verbatim.
+    pub cursor: Bytes,
+    /// Checkpoint coverage reported with this frame, when known, for progress observability.
+    pub covered_checkpoint: Option<u64>,
+}
+
+/// Polling, retry, buffering, and observability controls for `stream_*` operations.
+///
+/// Client-level timeouts bound individual RPCs, not the total duration of the stream.
+/// Finite `list_*` operations use the retry and observer controls in [`ListConfig`].
+#[non_exhaustive]
+#[derive(Clone)]
+pub struct LedgerStreamConfig {
+    /// Delay between polls when using `Poll` delivery. Must be non-zero.
+    pub ledger_tip_poll_interval: Duration,
+    /// Maximum items per internally built List request.
+    pub list_page_limit: Option<u32>,
+    /// Delay before the first transient retry.
+    pub base_retry_delay: Duration,
+    /// Maximum exponential portion of a retry delay.
+    pub max_retry_delay: Duration,
+    /// Maximum random jitter added to a retry delay.
+    pub retry_jitter: Duration,
+    /// Maximum number of live subscription items buffered during gap replay before reconnecting.
+    pub max_buffered_live_items: NonZeroUsize,
+    observer: Option<LedgerStreamObserver>,
+}
+
+impl fmt::Debug for LedgerStreamConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LedgerStreamConfig")
+            .field("ledger_tip_poll_interval", &self.ledger_tip_poll_interval)
+            .field("list_page_limit", &self.list_page_limit)
+            .field("base_retry_delay", &self.base_retry_delay)
+            .field("max_retry_delay", &self.max_retry_delay)
+            .field("retry_jitter", &self.retry_jitter)
+            .field("max_buffered_live_items", &self.max_buffered_live_items)
+            .field("observer_configured", &self.observer.is_some())
+            .finish()
+    }
+}
+
+impl Default for LedgerStreamConfig {
+    fn default() -> Self {
+        Self {
+            ledger_tip_poll_interval: Duration::from_secs(1),
+            list_page_limit: None,
+            base_retry_delay: Duration::from_millis(250),
+            max_retry_delay: Duration::from_secs(30),
+            retry_jitter: Duration::from_millis(500),
+            max_buffered_live_items: NonZeroUsize::new(1_024).expect("non-zero constant"),
+            observer: None,
+        }
+    }
+}
+
+impl LedgerStreamConfig {
+    /// Installs the synchronous stream observer, replacing any prior callback.
+    ///
+    /// The callback must return quickly and not block; its panic propagates to the polling task.
+    pub fn with_observer(
+        mut self,
+        observer: impl Fn(LedgerStreamEvent) + Send + Sync + 'static,
+    ) -> Self {
+        self.observer = Some(Arc::new(observer));
+        self
+    }
+
+    pub(super) fn observer(&self) -> Option<LedgerStreamObserver> {
+        self.observer.clone()
+    }
+}
+
+/// Retry and observability controls for finite `list_*` operations.
+#[non_exhaustive]
+#[derive(Clone)]
+pub struct ListConfig {
+    /// Delay before the first transient retry.
+    pub base_retry_delay: Duration,
+    /// Maximum exponential portion of a retry delay.
+    pub max_retry_delay: Duration,
+    /// Maximum random jitter added to a retry delay.
+    pub retry_jitter: Duration,
+    observer: Option<ListObserver>,
+}
+
+impl fmt::Debug for ListConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ListConfig")
+            .field("base_retry_delay", &self.base_retry_delay)
+            .field("max_retry_delay", &self.max_retry_delay)
+            .field("retry_jitter", &self.retry_jitter)
+            .field("observer_configured", &self.observer.is_some())
+            .finish()
+    }
+}
+
+impl Default for ListConfig {
+    fn default() -> Self {
+        let stream_defaults = LedgerStreamConfig::default();
+        Self {
+            base_retry_delay: stream_defaults.base_retry_delay,
+            max_retry_delay: stream_defaults.max_retry_delay,
+            retry_jitter: stream_defaults.retry_jitter,
+            observer: None,
+        }
+    }
+}
+
+impl ListConfig {
+    /// Installs the synchronous List observer, replacing any prior callback.
+    ///
+    /// The callback must return quickly and not block; its panic propagates to the polling task.
+    pub fn with_observer(mut self, observer: impl Fn(ListEvent) + Send + Sync + 'static) -> Self {
+        self.observer = Some(Arc::new(observer));
+        self
+    }
+
+    pub(super) fn into_stream_config(self) -> LedgerStreamConfig {
+        let observer: Option<LedgerStreamObserver> = self.observer.map(|list_observer| {
+            Arc::new(move |event: LedgerStreamEvent| {
+                if let Some(list_event) = ListEvent::from_stream_event(event) {
+                    list_observer(list_event);
+                }
+            }) as LedgerStreamObserver
+        });
+
+        LedgerStreamConfig {
+            base_retry_delay: self.base_retry_delay,
+            max_retry_delay: self.max_retry_delay,
+            retry_jitter: self.retry_jitter,
+            observer,
+            ..LedgerStreamConfig::default()
+        }
+    }
+}

--- a/crates/sui-rpc/src/client/mod.rs
+++ b/crates/sui-rpc/src/client/mod.rs
@@ -25,7 +25,25 @@ mod staking_rewards;
 pub use staking_rewards::DelegatedStake;
 
 mod coin_selection;
+mod ledger_streams;
 mod lists;
+pub use ledger_streams::CheckpointStreamFrame;
+pub use ledger_streams::CheckpointStreamRequest;
+pub use ledger_streams::CheckpointStreamStart;
+pub use ledger_streams::Delivery;
+pub use ledger_streams::EventStreamFrame;
+pub use ledger_streams::EventStreamRequest;
+pub use ledger_streams::EventStreamStart;
+pub use ledger_streams::LedgerStreamConfig;
+pub use ledger_streams::LedgerStreamEvent;
+pub use ledger_streams::LedgerStreamFamily;
+pub use ledger_streams::LedgerStreamOperation;
+pub use ledger_streams::LedgerStreamStage;
+pub use ledger_streams::ListConfig;
+pub use ledger_streams::ListEvent;
+pub use ledger_streams::TransactionStreamFrame;
+pub use ledger_streams::TransactionStreamRequest;
+pub use ledger_streams::TransactionStreamStart;
 
 mod transaction_execution;
 pub use transaction_execution::ExecuteAndWaitError;
@@ -75,6 +93,65 @@ const DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE: u32 = 64 * 1024 * 1024;
 /// All RPCs made through a client and its clones are multiplexed over a
 /// single HTTP/2 connection.
 ///
+/// # Ledger streams
+///
+/// `Client` provides two styles of stream operations for checkpoints, transactions, and events:
+///
+/// - `list_*` ([`list_checkpoints`](Client::list_checkpoints), [`list_transactions`](Client::list_transactions), [`list_events`](Client::list_events)):
+///   Finite pagination streams yielding raw response pages until reaching an end bound or the ledger tip.
+/// - `stream_*` ([`stream_checkpoints`](Client::stream_checkpoints), [`stream_transactions`](Client::stream_transactions), [`stream_events`](Client::stream_events)):
+///   Resumable, infinite streams starting from any position (`Tip`, `Checkpoint`, or `Resume` cursor)
+///   that automatically handle backfill replay, live subscription or polling, and transient error retries.
+///
+/// Stream read masks must include `sequence_number` for checkpoints; `checkpoint` and
+/// `transaction_index` for transactions; and `checkpoint`, `transaction_index`, and `event_index`
+/// for events (`"*"` satisfies all three).
+///
+/// Process a payload before persisting its restart position. To resume after a checkpoint, pass
+/// `cursor + 1` to [`CheckpointStreamStart::Checkpoint`]. To resume transactions or events, pass
+/// `frame.cursor` to [`TransactionStreamStart::Resume`] or [`EventStreamStart::Resume`].
+///
+/// ## Example
+///
+/// ```no_run
+/// # use futures::StreamExt;
+/// # use sui_rpc::field::{FieldMask, FieldMaskUtil};
+/// # use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
+/// # use sui_rpc::Client;
+/// # use sui_rpc::client::{TransactionStreamRequest, TransactionStreamStart};
+/// #
+/// # async fn process_transaction(_: &ExecutedTransaction) {}
+/// # async fn persist_position(_: &[u8]) {}
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = Client::new(Client::MAINNET_FULLNODE)?;
+/// let read_mask = FieldMask::from_paths(["checkpoint", "transaction_index", "digest"]);
+/// let request = TransactionStreamRequest::new().with_read_mask(read_mask.clone());
+///
+/// let mut stream = Box::pin(client.stream_transactions(request));
+/// let persisted = loop {
+///     let Some(frame) = stream.next().await else {
+///         return Ok(());
+///     };
+///     let frame = frame?;
+///
+///     if let Some(transaction) = &frame.transaction {
+///         process_transaction(transaction).await;
+///     }
+///     let persisted = frame.cursor.clone();
+///     persist_position(&persisted).await;
+///     break persisted;
+/// };
+/// drop(stream);
+///
+/// let restart_request = TransactionStreamRequest::new()
+///     .with_read_mask(read_mask)
+///     .with_start(TransactionStreamStart::Resume(persisted));
+/// let mut resumed = Box::pin(client.stream_transactions(restart_request));
+/// let _ = resumed.next().await;
+/// # Ok(())
+/// # }
+/// ```
+///
 /// # Timeouts and deadlines
 ///
 /// No default bounds the total duration of a call. Two opt-in bounds are
@@ -86,6 +163,13 @@ const DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE: u32 = 64 * 1024 * 1024;
 ///   end: tonic bounds the wait for response headers, and the client's
 ///   watchdog (see [`with_body_idle_timeout`](Client::with_body_idle_timeout))
 ///   bounds the response body against the same deadline.
+///   The ledger-stream `list_*` and `stream_*` methods do not accept
+///   `tonic::Request`. One logical operation may issue several RPCs, so per-RPC
+///   authentication, common headers, tracing, and timeouts belong on the
+///   client: static headers on [`Client::with_headers`], dynamic per-RPC auth
+///   or tracing on [`Client::request_layer`]. Configuring a [`Clone`]d client
+///   affects only that clone and shares the underlying connection, so a single
+///   stream gets dedicated headers by receiving a configured clone.
 /// - A client-wide response-headers timeout set with
 ///   [`with_response_headers_timeout`](Client::with_response_headers_timeout).
 ///   This is enforced locally only and its timer stops once response headers

--- a/crates/sui-rpc/tests/ledger_streams/list.rs
+++ b/crates/sui-rpc/tests/ledger_streams/list.rs
@@ -13,12 +13,20 @@ use super::support::event_list_frame;
 use super::support::event_positioned_list_frame;
 use super::support::fast_list_config;
 use super::support::observed_client;
+use super::support::service_info;
 use super::support::spawn_server;
 use super::support::transaction_identity_mask;
 use super::support::transaction_list_frame;
+use futures::StreamExt;
 use futures::TryStreamExt;
 use std::time::Duration;
+use sui_rpc::client::CheckpointStreamRequest;
+use sui_rpc::client::CheckpointStreamStart;
+use sui_rpc::client::EventStreamRequest;
+use sui_rpc::client::EventStreamStart;
 use sui_rpc::client::ListConfig;
+use sui_rpc::client::TransactionStreamRequest;
+use sui_rpc::client::TransactionStreamStart;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use tokio::sync::mpsc;
 
@@ -502,6 +510,199 @@ async fn sparse_bounded_streams_yield_progress_and_the_final_watermark() {
     assert_eq!(
         event_frames.last().unwrap().end.as_ref().unwrap().reason,
         Some(proto::QueryEndReason::CheckpointBound as i32)
+    );
+}
+
+#[tokio::test]
+async fn stream_position_round_trips_through_bytes() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([2, 4, 2, 4, 2, 4].into_iter().map(service_info).map(Ok));
+    server.push_checkpoint_lists([
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(2), 2, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(3), 3, None)),
+            Ok(checkpoint_list_frame(Some(4), 4, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                4,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    server.push_transaction_lists([
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(2), 2, None)),
+            Ok(transaction_list_frame(
+                None,
+                3,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(3), 3, None)),
+            Ok(transaction_list_frame(Some(4), 4, None)),
+            Ok(transaction_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(2), 2, None)),
+            Ok(event_list_frame(
+                None,
+                3,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(3), 3, None)),
+            Ok(event_list_frame(Some(4), 4, None)),
+            Ok(event_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let checkpoint_request = CheckpointStreamRequest::new()
+        .with_read_mask(checkpoint_identity_mask())
+        .with_start(CheckpointStreamStart::Checkpoint(2));
+    let checkpoint_frames = client
+        .stream_checkpoints(checkpoint_request)
+        .take(1)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        checkpoint_frames[0]
+            .checkpoint
+            .as_ref()
+            .unwrap()
+            .sequence_number,
+        Some(2)
+    );
+    assert_eq!(checkpoint_frames[0].cursor, 2);
+    assert_eq!(checkpoint_frames.len(), 1);
+
+    let checkpoint_resume = CheckpointStreamRequest::new()
+        .with_read_mask(checkpoint_identity_mask())
+        .with_start(CheckpointStreamStart::Checkpoint(
+            checkpoint_frames[0].cursor.checked_add(1).unwrap(),
+        ));
+    let checkpoints = client
+        .stream_checkpoints(checkpoint_resume)
+        .take(2)
+        .try_filter_map(|frame| async move {
+            Ok(frame
+                .checkpoint
+                .map(|checkpoint| checkpoint.sequence_number.unwrap()))
+        })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(checkpoints, [3, 4]);
+
+    let transaction_request = TransactionStreamRequest::new()
+        .with_read_mask(transaction_identity_mask())
+        .with_start(TransactionStreamStart::Checkpoint(2));
+    let transaction_frames = client
+        .stream_transactions(transaction_request)
+        .take(1)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        transaction_frames[0]
+            .transaction
+            .as_ref()
+            .unwrap()
+            .digest
+            .as_deref(),
+        Some("tx-2")
+    );
+    assert_eq!(transaction_frames[0].cursor, bytes(2));
+    assert_eq!(transaction_frames[0].covered_checkpoint, Some(2));
+
+    let persisted = transaction_frames[0].cursor.clone();
+    let transaction_resume = TransactionStreamRequest::new()
+        .with_read_mask(transaction_identity_mask())
+        .with_start(TransactionStreamStart::Resume(persisted));
+    let transactions = client
+        .stream_transactions(transaction_resume)
+        .take(2)
+        .try_filter_map(|frame| async move {
+            Ok(frame
+                .transaction
+                .map(|transaction| transaction.digest.unwrap()))
+        })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(transactions, ["tx-3", "tx-4"]);
+
+    let event_request = EventStreamRequest::new()
+        .with_read_mask(event_identity_mask())
+        .with_start(EventStreamStart::Checkpoint(2));
+    let event_frames = client
+        .stream_events(event_request)
+        .take(1)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        event_frames[0]
+            .event
+            .as_ref()
+            .unwrap()
+            .event_type
+            .as_deref(),
+        Some("event-2")
+    );
+    assert_eq!(event_frames[0].cursor, bytes(2));
+    assert_eq!(event_frames[0].covered_checkpoint, Some(2));
+
+    let event_resume = EventStreamRequest::new()
+        .with_read_mask(event_identity_mask())
+        .with_start(EventStreamStart::Resume(event_frames[0].cursor.clone()));
+    let events = client
+        .stream_events(event_resume)
+        .take(2)
+        .try_filter_map(
+            |frame| async move { Ok(frame.event.map(|event| event.event_type.unwrap())) },
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(events, ["event-3", "event-4"]);
+
+    let state = server.state.lock().unwrap();
+
+    assert_eq!(state.checkpoint_requests[1].body.start_checkpoint, Some(3));
+    assert_eq!(
+        state.transaction_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .after,
+        Some(bytes(2))
+    );
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(2))
     );
 }
 

--- a/crates/sui-rpc/tests/ledger_streams/list.rs
+++ b/crates/sui-rpc/tests/ledger_streams/list.rs
@@ -1,0 +1,1484 @@
+use super::support::STREAM_DROP_TIMEOUT;
+use super::support::ScriptedStreamServer;
+use super::support::StreamScript;
+use super::support::bounded_checkpoint_scripts;
+use super::support::bounded_event_request;
+use super::support::bounded_event_scripts;
+use super::support::bounded_transaction_scripts;
+use super::support::bytes;
+use super::support::checkpoint_identity_mask;
+use super::support::checkpoint_list_frame;
+use super::support::event_identity_mask;
+use super::support::event_list_frame;
+use super::support::event_positioned_list_frame;
+use super::support::fast_list_config;
+use super::support::observed_client;
+use super::support::spawn_server;
+use super::support::transaction_identity_mask;
+use super::support::transaction_list_frame;
+use futures::TryStreamExt;
+use std::time::Duration;
+use sui_rpc::client::ListConfig;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn list_observer_events_receive_list_events() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        5,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let (observer_tx, mut observer_events) = mpsc::unbounded_channel();
+    let config = fast_list_config().with_observer(move |event| {
+        observer_tx.send(event).unwrap();
+    });
+
+    client
+        .list_events_with_config(bounded_event_request().with_end_checkpoint(6), config)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    match observer_events.try_recv().unwrap() {
+        sui_rpc::client::ListEvent::RpcResponse { family, code, .. } => {
+            assert_eq!(family, sui_rpc::client::LedgerStreamFamily::Event);
+            assert_eq!(code, tonic::Code::Ok);
+        }
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+}
+
+#[tokio::test]
+async fn lists_continue_pagination_then_stop_at_ledger_tip_for_all_families() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_checkpoint_lists(bounded_checkpoint_scripts());
+    server.push_transaction_lists(bounded_transaction_scripts());
+    server.push_event_lists(bounded_event_scripts());
+    let address = spawn_server(server.clone()).await;
+    let (client, observations) = observed_client(address);
+
+    let options = proto::QueryOptions::default()
+        .with_limit(2)
+        .with_ordering(proto::Ordering::Ascending);
+    let checkpoint_request = proto::ListCheckpointsRequest::default()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec!["digest".to_owned(), "sequence_number".to_owned()],
+        })
+        .with_filter(proto::TransactionFilter::default())
+        .with_start_checkpoint(2)
+        .with_end_checkpoint(8)
+        .with_options(options.clone());
+    let checkpoint_responses = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .list_checkpoints_with_config(checkpoint_request, fast_list_config())
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for paginated checkpoints")
+    .unwrap();
+    assert_eq!(
+        checkpoint_responses
+            .iter()
+            .filter_map(|response| response.checkpoint.as_ref())
+            .count(),
+        4
+    );
+    assert!(
+        checkpoint_responses
+            .iter()
+            .filter_map(|response| response.checkpoint.as_ref())
+            .all(|checkpoint| checkpoint.sequence_number.is_some())
+    );
+
+    let transaction_request = proto::ListTransactionsRequest::default()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec![
+                "digest".to_owned(),
+                "checkpoint".to_owned(),
+                "transaction_index".to_owned(),
+            ],
+        })
+        .with_filter(proto::TransactionFilter::default())
+        .with_start_checkpoint(2)
+        .with_end_checkpoint(8)
+        .with_options(options.clone());
+    let transaction_responses = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .list_transactions_with_config(transaction_request, fast_list_config())
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for paginated transactions")
+    .unwrap();
+    assert_eq!(
+        transaction_responses
+            .iter()
+            .filter_map(|response| response.transaction.as_ref())
+            .map(|transaction| transaction.digest.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        ["tx-2", "tx-3", "tx-6", "tx-7"]
+    );
+    assert!(
+        transaction_responses
+            .iter()
+            .filter_map(|response| response.transaction.as_ref())
+            .all(|transaction| {
+                transaction.checkpoint.is_some() && transaction.transaction_index.is_some()
+            })
+    );
+
+    let event_request = proto::ListEventsRequest::default()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec![
+                "event_type".to_owned(),
+                "checkpoint".to_owned(),
+                "transaction_index".to_owned(),
+                "event_index".to_owned(),
+            ],
+        })
+        .with_filter(proto::EventFilter::default())
+        .with_start_checkpoint(2)
+        .with_end_checkpoint(8)
+        .with_options(options);
+    let event_responses = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .list_events_with_config(event_request, fast_list_config())
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for paginated events")
+    .unwrap();
+    assert_eq!(
+        event_responses
+            .iter()
+            .filter_map(|response| response.event.as_ref())
+            .map(|event| event.event_type.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        ["event-2", "event-3", "event-6", "event-7"]
+    );
+    assert!(
+        event_responses
+            .iter()
+            .filter_map(|response| response.event.as_ref())
+            .all(|event| {
+                event.checkpoint.is_some()
+                    && event.transaction_index.is_some()
+                    && event.event_index.is_some()
+            })
+    );
+
+    for reasons in [
+        checkpoint_responses
+            .iter()
+            .map(|response| response.end.as_ref().and_then(|end| end.reason))
+            .collect::<Vec<_>>(),
+        transaction_responses
+            .iter()
+            .map(|response| response.end.as_ref().and_then(|end| end.reason))
+            .collect::<Vec<_>>(),
+        event_responses
+            .iter()
+            .map(|response| response.end.as_ref().and_then(|end| end.reason))
+            .collect::<Vec<_>>(),
+    ] {
+        assert_eq!(
+            reasons,
+            [
+                None,
+                Some(proto::QueryEndReason::ItemLimit as i32),
+                None,
+                None,
+                None,
+                Some(proto::QueryEndReason::LedgerTip as i32),
+            ]
+        );
+    }
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.checkpoint_requests.len(), 2);
+    assert_eq!(state.transaction_requests.len(), 2);
+    assert_eq!(state.event_requests.len(), 2);
+    assert_eq!(state.calls.len(), 6);
+    assert!(state.calls.iter().all(|call| call.starts_with("list_")));
+    for options in state
+        .checkpoint_requests
+        .iter()
+        .map(|request| &request.body.options)
+        .chain(
+            state
+                .transaction_requests
+                .iter()
+                .map(|request| &request.body.options),
+        )
+        .chain(
+            state
+                .event_requests
+                .iter()
+                .map(|request| &request.body.options),
+        )
+    {
+        let options = options.as_ref().unwrap();
+        assert_eq!(options.limit, Some(2));
+        assert_eq!(options.ordering, Some(proto::Ordering::Ascending as i32));
+    }
+    assert_eq!(
+        state.checkpoint_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .after,
+        Some(bytes(3))
+    );
+    assert_eq!(
+        state.transaction_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .after,
+        Some(bytes(3))
+    );
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(3))
+    );
+    drop(state);
+
+    let observations = observations.lock().unwrap();
+    assert_eq!(observations.len(), 6);
+    assert!(
+        observations
+            .iter()
+            .all(|observation| observation.path.contains("List"))
+    );
+}
+
+#[tokio::test]
+async fn default_lists_insert_only_the_required_resume_bound() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_checkpoint_lists([
+        StreamScript::frames([Ok(checkpoint_list_frame(
+            Some(1),
+            1,
+            Some(proto::QueryEndReason::ItemLimit),
+        ))]),
+        StreamScript::frames([Ok(checkpoint_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+    ]);
+    server.push_transaction_lists([
+        StreamScript::frames([Ok(transaction_list_frame(
+            Some(1),
+            1,
+            Some(proto::QueryEndReason::ItemLimit),
+        ))]),
+        StreamScript::frames([Ok(transaction_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            Some(1),
+            1,
+            Some(proto::QueryEndReason::ItemLimit),
+        ))]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    assert_eq!(
+        client
+            .list_checkpoints(
+                proto::ListCheckpointsRequest::default().with_read_mask(checkpoint_identity_mask()),
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(
+        client
+            .list_transactions(
+                proto::ListTransactionsRequest::default()
+                    .with_read_mask(transaction_identity_mask()),
+            )
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(
+        client
+            .list_events(proto::ListEventsRequest::default().with_read_mask(event_identity_mask()),)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+
+    let state = server.state.lock().unwrap();
+    for (first, second) in [
+        (
+            &state.checkpoint_requests[0].body.options,
+            &state.checkpoint_requests[1].body.options,
+        ),
+        (
+            &state.transaction_requests[0].body.options,
+            &state.transaction_requests[1].body.options,
+        ),
+        (
+            &state.event_requests[0].body.options,
+            &state.event_requests[1].body.options,
+        ),
+    ] {
+        assert!(first.is_none());
+        let continuation = second.as_ref().unwrap();
+        assert_eq!(continuation.after, Some(bytes(1)));
+        assert!(continuation.before.is_none());
+        assert!(continuation.limit.is_none());
+        assert!(continuation.ordering.is_none());
+    }
+}
+
+#[tokio::test]
+async fn sparse_bounded_streams_yield_progress_and_the_final_watermark() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_checkpoint_lists([StreamScript::frames([
+        Ok(checkpoint_list_frame(None, 2, None)),
+        Ok(checkpoint_list_frame(Some(3), 3, None)),
+        Ok(checkpoint_list_frame(
+            None,
+            4,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    server.push_transaction_lists([StreamScript::frames([
+        Ok(transaction_list_frame(None, 2, None)),
+        Ok(transaction_list_frame(Some(3), 3, None)),
+        Ok(transaction_list_frame(
+            None,
+            5,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    server.push_event_lists([StreamScript::frames([
+        Ok(event_list_frame(None, 2, None)),
+        Ok(event_list_frame(Some(3), 3, None)),
+        Ok(event_list_frame(
+            None,
+            5,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let checkpoint_frames = client
+        .list_checkpoints(
+            proto::ListCheckpointsRequest::default()
+                .with_read_mask(checkpoint_identity_mask())
+                .with_end_checkpoint(5),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        checkpoint_frames
+            .iter()
+            .map(|frame| {
+                frame
+                    .checkpoint
+                    .as_ref()
+                    .and_then(|checkpoint| checkpoint.sequence_number)
+            })
+            .collect::<Vec<_>>(),
+        [None, Some(3), None]
+    );
+    assert_eq!(
+        checkpoint_frames
+            .iter()
+            .map(|frame| frame.watermark.as_ref().unwrap().checkpoint.unwrap())
+            .collect::<Vec<_>>(),
+        [2, 3, 4]
+    );
+    assert_eq!(
+        checkpoint_frames
+            .last()
+            .unwrap()
+            .end
+            .as_ref()
+            .unwrap()
+            .reason,
+        Some(proto::QueryEndReason::CheckpointBound as i32)
+    );
+
+    let transaction_frames = client
+        .list_transactions(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_end_checkpoint(6),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        transaction_frames
+            .iter()
+            .map(|frame| {
+                frame
+                    .transaction
+                    .as_ref()
+                    .and_then(|transaction| transaction.digest.as_deref())
+            })
+            .collect::<Vec<_>>(),
+        [None, Some("tx-3"), None]
+    );
+    assert_eq!(
+        transaction_frames
+            .iter()
+            .map(|frame| frame.watermark.as_ref().unwrap().cursor.clone().unwrap())
+            .collect::<Vec<_>>(),
+        [bytes(2), bytes(3), bytes(5)]
+    );
+    assert_eq!(
+        transaction_frames
+            .last()
+            .unwrap()
+            .end
+            .as_ref()
+            .unwrap()
+            .reason,
+        Some(proto::QueryEndReason::CheckpointBound as i32)
+    );
+
+    let event_frames = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_end_checkpoint(6),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        event_frames
+            .iter()
+            .map(|frame| {
+                frame
+                    .event
+                    .as_ref()
+                    .and_then(|event| event.event_type.as_deref())
+            })
+            .collect::<Vec<_>>(),
+        [None, Some("event-3"), None]
+    );
+    assert_eq!(
+        event_frames
+            .iter()
+            .map(|frame| frame.watermark.as_ref().unwrap().cursor.clone().unwrap())
+            .collect::<Vec<_>>(),
+        [bytes(2), bytes(3), bytes(5)]
+    );
+    assert_eq!(
+        event_frames.last().unwrap().end.as_ref().unwrap().reason,
+        Some(proto::QueryEndReason::CheckpointBound as i32)
+    );
+}
+
+#[tokio::test]
+async fn list_accepts_checkpoint_cursor_and_intersection_bounds() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let mut checkpoint_bounded_end =
+        event_list_frame(None, 10, Some(proto::QueryEndReason::CheckpointBound));
+    checkpoint_bounded_end
+        .watermark
+        .as_mut()
+        .unwrap()
+        .checkpoint = Some(9);
+    let mut intersection_bounded_end =
+        event_list_frame(None, 30, Some(proto::QueryEndReason::CheckpointBound));
+    intersection_bounded_end
+        .watermark
+        .as_mut()
+        .unwrap()
+        .checkpoint = Some(29);
+    server.push_event_lists([
+        StreamScript::frames([Ok(checkpoint_bounded_end)]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            20,
+            Some(proto::QueryEndReason::CursorBound),
+        ))]),
+        StreamScript::frames([Ok(intersection_bounded_end)]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let requests = [
+        proto::ListEventsRequest::default()
+            .with_read_mask(event_identity_mask())
+            .with_start_checkpoint(2)
+            .with_end_checkpoint(10)
+            .with_options(
+                proto::QueryOptions::default()
+                    .with_after(bytes(1))
+                    .with_limit(7),
+            ),
+        proto::ListEventsRequest::default()
+            .with_read_mask(event_identity_mask())
+            .with_options(proto::QueryOptions::default().with_before(bytes(20))),
+        proto::ListEventsRequest::default()
+            .with_read_mask(event_identity_mask())
+            .with_end_checkpoint(30)
+            .with_options(proto::QueryOptions::default().with_before(bytes(30))),
+    ];
+    for request_body in requests {
+        let frames = client
+            .list_events_with_config(request_body, fast_list_config())
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].event.is_none());
+    }
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_requests.len(), 3);
+    assert!(state.calls.iter().all(|call| *call == "list_events"));
+}
+
+#[tokio::test]
+async fn opaque_checkpoint_bound_accepts_server_reported_coverage() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_transaction_lists([StreamScript::frames([Ok(transaction_list_frame(
+        None,
+        10,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        10,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let tx_responses = client
+        .list_transactions(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_end_checkpoint(10),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(tx_responses.len(), 1);
+    assert_eq!(
+        tx_responses[0].watermark.as_ref().unwrap().checkpoint,
+        Some(10)
+    );
+
+    let event_responses = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_end_checkpoint(10),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(event_responses.len(), 1);
+    assert_eq!(
+        event_responses[0].watermark.as_ref().unwrap().checkpoint,
+        Some(10)
+    );
+
+    assert_eq!(
+        server.state.lock().unwrap().calls,
+        ["list_transactions", "list_events"]
+    );
+}
+
+#[tokio::test]
+async fn descending_event_checkpoint_bound_accepts_server_reported_opaque_coverage() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        5,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let responses = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_start_checkpoint(4)
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].watermark.as_ref().unwrap().checkpoint, Some(5));
+    assert_eq!(server.state.lock().unwrap().calls, ["list_events"]);
+}
+
+#[tokio::test]
+async fn list_carries_checkpoint_coverage_across_continuation_requests() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let mut continued_item = event_list_frame(Some(6), 6, None);
+    continued_item.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Err(tonic::Status::unavailable("partial response")),
+        ]),
+        StreamScript::frames([
+            Ok(continued_item),
+            Ok(event_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let frames = client
+        .list_events_with_config(
+            bounded_event_request().with_end_checkpoint(8),
+            fast_list_config(),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        frames
+            .iter()
+            .map(|frame| frame.watermark.as_ref().unwrap().cursor.clone().unwrap())
+            .collect::<Vec<_>>(),
+        [bytes(5), bytes(6), bytes(7)]
+    );
+    assert_eq!(
+        frames
+            .iter()
+            .map(|frame| frame.watermark.as_ref().unwrap().checkpoint)
+            .collect::<Vec<_>>(),
+        [Some(5), None, Some(7)]
+    );
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_requests.len(), 2);
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(5))
+    );
+}
+
+#[tokio::test]
+async fn list_accepts_missing_coverage_before_the_request_establishes_it() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let mut first = event_list_frame(Some(0), 0, None);
+    first.watermark.as_mut().unwrap().checkpoint = None;
+    let mut second = event_list_frame(Some(1), 1, None);
+    second.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_event_lists([StreamScript::frames([
+        Ok(first),
+        Ok(second),
+        Ok(event_list_frame(
+            None,
+            1,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let frames = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_start_checkpoint(0)
+                .with_end_checkpoint(2),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(
+        frames
+            .iter()
+            .filter_map(|frame| frame.event.as_ref())
+            .map(|event| event.event_type.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        ["event-0", "event-1"]
+    );
+    assert_eq!(frames[0].watermark.as_ref().unwrap().checkpoint, None);
+    assert_eq!(frames[1].watermark.as_ref().unwrap().checkpoint, None);
+}
+
+#[tokio::test]
+async fn list_accepts_empty_continuation_without_checkpoint_coverage() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let mut empty_terminal =
+        event_list_frame(None, 5, Some(proto::QueryEndReason::CheckpointBound));
+    empty_terminal.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Err(tonic::Status::unavailable("partial response")),
+        ]),
+        StreamScript::frames([Ok(empty_terminal)]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let frames = client
+        .list_events_with_config(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_end_checkpoint(6),
+            fast_list_config(),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(
+        frames[0].event.as_ref().unwrap().event_type.as_deref(),
+        Some("event-5")
+    );
+    assert!(frames[1].event.is_none());
+    assert_eq!(frames[1].watermark.as_ref().unwrap().checkpoint, None);
+    assert_eq!(
+        frames[1].end.as_ref().unwrap().reason,
+        Some(proto::QueryEndReason::CheckpointBound as i32)
+    );
+    assert_eq!(server.state.lock().unwrap().event_requests.len(), 2);
+}
+
+#[tokio::test]
+async fn scan_limit_frontiers_redispatch_immediately_when_the_cursor_advances() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    let (repeated_scan_tx, repeated_scan_rx) = mpsc::unbounded_channel();
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::ScanLimit),
+        ))]),
+        StreamScript::Channel(repeated_scan_rx),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(event_positioned_list_frame(
+                None,
+                10,
+                9,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = ListConfig::default();
+    config.base_retry_delay = Duration::from_secs(60);
+    config.max_retry_delay = Duration::from_secs(60);
+    config.retry_jitter = Duration::ZERO;
+    let collector = tokio::spawn(async move {
+        client
+            .list_events_with_config(bounded_event_request(), config)
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.event_type.unwrap()))
+            })
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(calls.recv().await, Some("list_events"));
+    assert_eq!(calls.recv().await, Some("list_events"));
+    repeated_scan_tx
+        .send(Ok(event_list_frame(
+            None,
+            4,
+            Some(proto::QueryEndReason::ScanLimit),
+        )))
+        .unwrap();
+    assert_eq!(
+        tokio::time::timeout(STREAM_DROP_TIMEOUT, calls.recv())
+            .await
+            .expect("ScanLimit continuation was delayed"),
+        Some("list_events")
+    );
+    assert_eq!(collector.await.unwrap().unwrap(), ["event-5"]);
+}
+
+#[tokio::test]
+async fn descending_streams_are_list_only_and_normalize_genesis_for_all_families() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_checkpoint_lists([StreamScript::frames([
+        Ok(checkpoint_list_frame(Some(9), 9, None)),
+        Ok(checkpoint_list_frame(Some(7), 7, None)),
+        Ok(checkpoint_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    server.push_transaction_lists([StreamScript::frames([
+        Ok(transaction_list_frame(Some(9), 9, None)),
+        Ok(transaction_list_frame(Some(7), 7, None)),
+        Ok(transaction_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    server.push_event_lists([StreamScript::frames([
+        Ok(event_list_frame(Some(9), 9, None)),
+        Ok(event_list_frame(Some(7), 7, None)),
+        Ok(event_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let checkpoint_ids = client
+        .list_checkpoints(
+            proto::ListCheckpointsRequest::default()
+                .with_read_mask(checkpoint_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_filter_map(|frame| async move {
+            Ok(frame
+                .checkpoint
+                .and_then(|checkpoint| checkpoint.sequence_number))
+        })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let transaction_ids = client
+        .list_transactions(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_filter_map(|frame| async move {
+            Ok(frame
+                .transaction
+                .and_then(|transaction| transaction.checkpoint))
+        })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let event_ids = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_filter_map(|frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(checkpoint_ids, [9, 7]);
+    assert_eq!(transaction_ids, [9, 7]);
+    assert_eq!(event_ids, [9, 7]);
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.calls,
+        ["list_checkpoints", "list_transactions", "list_events"]
+    );
+    assert!(state.checkpoint_subscriptions.is_empty());
+    assert!(state.transaction_subscriptions.is_empty());
+    assert!(state.event_subscriptions.is_empty());
+    assert_eq!(state.checkpoint_requests[0].body.start_checkpoint, None);
+    assert_eq!(state.transaction_requests[0].body.start_checkpoint, None);
+    assert_eq!(state.event_requests[0].body.start_checkpoint, None);
+    for options in [
+        state.checkpoint_requests[0].body.options.as_ref().unwrap(),
+        state.transaction_requests[0].body.options.as_ref().unwrap(),
+        state.event_requests[0].body.options.as_ref().unwrap(),
+    ] {
+        assert_eq!(options.ordering, Some(proto::Ordering::Descending as i32));
+        assert!(options.after.is_none());
+        assert!(options.before.is_none());
+    }
+}
+
+#[tokio::test]
+async fn descending_item_and_scan_limits_resume_through_before_and_preserve_after() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_transaction_lists([
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(9), 9, None)),
+            Ok(transaction_list_frame(
+                Some(8),
+                8,
+                Some(proto::QueryEndReason::ItemLimit),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(7), 7, None)),
+            Ok(transaction_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            8,
+            Some(proto::QueryEndReason::ScanLimit),
+        ))]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(7), 7, None)),
+            Ok(event_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let transaction_ids = client
+        .list_transactions(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_after(bytes(5))
+                        .with_before(bytes(10))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_filter_map(|frame| async move {
+            Ok(frame
+                .transaction
+                .and_then(|transaction| transaction.checkpoint))
+        })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let event_ids = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_after(bytes(5))
+                        .with_before(bytes(10))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_filter_map(|frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(transaction_ids, [9, 8, 7]);
+    assert_eq!(event_ids, [7]);
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.calls,
+        [
+            "list_transactions",
+            "list_transactions",
+            "list_events",
+            "list_events"
+        ]
+    );
+    assert!(state.transaction_subscriptions.is_empty());
+    assert!(state.event_subscriptions.is_empty());
+    for request in [
+        &state.transaction_requests[0],
+        &state.transaction_requests[1],
+    ] {
+        let options = request.body.options.as_ref().unwrap();
+        assert_eq!(options.after, Some(bytes(5)));
+        assert_eq!(options.ordering, Some(proto::Ordering::Descending as i32));
+    }
+    assert_eq!(
+        state.transaction_requests[0]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(10))
+    );
+    assert_eq!(
+        state.transaction_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(8))
+    );
+    for request in [&state.event_requests[0], &state.event_requests[1]] {
+        let options = request.body.options.as_ref().unwrap();
+        assert_eq!(options.after, Some(bytes(5)));
+        assert_eq!(options.ordering, Some(proto::Ordering::Descending as i32));
+    }
+    assert_eq!(
+        state.event_requests[0]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(10))
+    );
+    assert_eq!(
+        state.event_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(8))
+    );
+}
+
+#[tokio::test]
+async fn descending_partial_response_retry_resumes_through_before() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(9), 9, None)),
+            Err(tonic::Status::unavailable("partial response")),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(8), 8, None)),
+            Ok(event_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let event_ids = client
+        .list_events_with_config(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_after(bytes(5))
+                        .with_before(bytes(10))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+            fast_list_config(),
+        )
+        .try_filter_map(|frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(event_ids, [9, 8]);
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.calls, ["list_events", "list_events"]);
+    let retry_options = state.event_requests[1].body.options.as_ref().unwrap();
+    assert_eq!(retry_options.after, Some(bytes(5)));
+    assert_eq!(retry_options.before, Some(bytes(9)));
+    assert_eq!(
+        retry_options.ordering,
+        Some(proto::Ordering::Descending as i32)
+    );
+}
+
+#[tokio::test]
+async fn descending_accepts_low_cursor_completion_and_empty_ledger_tip() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_transaction_lists([StreamScript::frames([Ok(transaction_list_frame(
+        None,
+        5,
+        Some(proto::QueryEndReason::CursorBound),
+    ))])]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        9,
+        Some(proto::QueryEndReason::LedgerTip),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let transaction_frames = client
+        .list_transactions(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_after(bytes(5))
+                        .with_before(bytes(5))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let event_frames = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(transaction_frames.len(), 1);
+    assert!(transaction_frames[0].transaction.is_none());
+    assert_eq!(
+        transaction_frames[0].end.as_ref().unwrap().reason,
+        Some(proto::QueryEndReason::CursorBound as i32)
+    );
+    assert_eq!(event_frames.len(), 1);
+    assert!(event_frames[0].event.is_none());
+    assert_eq!(
+        event_frames[0].watermark.as_ref().unwrap().cursor,
+        Some(bytes(9))
+    );
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.calls, ["list_transactions", "list_events"]);
+    assert!(state.transaction_subscriptions.is_empty());
+    assert!(state.event_subscriptions.is_empty());
+    assert_eq!(state.event_requests[0].body.start_checkpoint, None);
+}
+
+#[tokio::test]
+async fn nonempty_fixed_streams_reject_entry_side_terminal_reasons() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_transaction_lists([StreamScript::frames([
+        Ok(transaction_list_frame(Some(9), 9, None)),
+        Ok(transaction_list_frame(
+            None,
+            5,
+            Some(proto::QueryEndReason::CursorBound),
+        )),
+    ])]);
+    server.push_event_lists([StreamScript::frames([
+        Ok(event_list_frame(Some(1), 1, None)),
+        Ok(event_list_frame(
+            None,
+            10,
+            Some(proto::QueryEndReason::CursorBound),
+        )),
+    ])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let descending_status = client
+        .list_transactions(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_start_checkpoint(0)
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_before(bytes(10))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap_err();
+    assert_eq!(descending_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        descending_status.message(),
+        "List ended at an unexpected bound"
+    );
+
+    let ascending_status = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_end_checkpoint(10)
+                .with_options(proto::QueryOptions::default().with_after(bytes(0))),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap_err();
+    assert_eq!(ascending_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        ascending_status.message(),
+        "List ended at an unexpected bound"
+    );
+}
+
+#[tokio::test]
+async fn empty_descending_stream_accepts_entry_side_cursor_bound() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        0,
+        Some(proto::QueryEndReason::CursorBound),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let frames = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_before(bytes(0))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(frames.len(), 1);
+    assert!(frames[0].event.is_none());
+    assert_eq!(
+        frames[0].end.as_ref().unwrap().reason,
+        Some(proto::QueryEndReason::CursorBound as i32)
+    );
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_requests[0].body.start_checkpoint, None);
+    assert!(state.event_subscriptions.is_empty());
+}
+
+#[tokio::test]
+async fn progress_only_fixed_streams_reject_entry_side_or_ledger_tip_termination() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([StreamScript::frames([
+        Ok(event_list_frame(None, 9, None)),
+        Ok(event_list_frame(
+            None,
+            5,
+            Some(proto::QueryEndReason::CursorBound),
+        )),
+    ])]);
+    server.push_transaction_lists([StreamScript::frames([
+        Ok(transaction_list_frame(None, 9, None)),
+        Ok(transaction_list_frame(
+            None,
+            9,
+            Some(proto::QueryEndReason::LedgerTip),
+        )),
+    ])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let cursor_status = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_start_checkpoint(0)
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_before(bytes(10))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap_err();
+    assert_eq!(cursor_status.code(), tonic::Code::DataLoss);
+    assert_eq!(cursor_status.message(), "List ended at an unexpected bound");
+
+    let ledger_tip_status = client
+        .list_transactions(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap_err();
+    assert_eq!(ledger_tip_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        ledger_tip_status.message(),
+        "descending List reached LedgerTip after prior scan progress"
+    );
+}
+
+#[tokio::test]
+async fn descending_retry_accepts_terminal_only_empty_intersection() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(9), 9, None)),
+            Err(tonic::Status::unavailable("partial response")),
+        ]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            9,
+            Some(proto::QueryEndReason::CursorBound),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let events = client
+        .list_events_with_config(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_start_checkpoint(9)
+                .with_options(
+                    proto::QueryOptions::default()
+                        .with_before(bytes(10))
+                        .with_ordering(proto::Ordering::Descending),
+                ),
+            fast_list_config(),
+        )
+        .try_filter_map(|frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(events, [9]);
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_requests.len(), 2);
+    assert_eq!(
+        state.event_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(9))
+    );
+}
+
+#[tokio::test]
+async fn descending_retry_rejects_terminal_only_ledger_tip_after_progress() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_transaction_lists([
+        StreamScript::frames([
+            Ok(transaction_list_frame(None, 9, None)),
+            Err(tonic::Status::unavailable("partial response")),
+        ]),
+        StreamScript::frames([Ok(transaction_list_frame(
+            None,
+            9,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let status = client
+        .list_transactions_with_config(
+            proto::ListTransactionsRequest::default()
+                .with_read_mask(transaction_identity_mask())
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+            fast_list_config(),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "descending List reached LedgerTip after prior scan progress"
+    );
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.transaction_requests.len(), 2);
+    assert_eq!(
+        state.transaction_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(9))
+    );
+}
+
+#[tokio::test]
+async fn descending_item_limit_accepts_terminal_only_resume_cursor_bound() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            Some(9),
+            9,
+            Some(proto::QueryEndReason::ItemLimit),
+        ))]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            9,
+            Some(proto::QueryEndReason::CursorBound),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let events = client
+        .list_events(
+            proto::ListEventsRequest::default()
+                .with_read_mask(event_identity_mask())
+                .with_start_checkpoint(9)
+                .with_options(
+                    proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+                ),
+        )
+        .try_filter_map(|frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert_eq!(events, [9]);
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_requests.len(), 2);
+    assert_eq!(
+        state.event_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(9))
+    );
+}

--- a/crates/sui-rpc/tests/ledger_streams/main.rs
+++ b/crates/sui-rpc/tests/ledger_streams/main.rs
@@ -1,4 +1,7 @@
 mod list;
 mod malformed_protocol;
+mod observability;
+mod polling;
 mod reconnect;
+mod startup;
 mod support;

--- a/crates/sui-rpc/tests/ledger_streams/main.rs
+++ b/crates/sui-rpc/tests/ledger_streams/main.rs
@@ -1,0 +1,4 @@
+mod list;
+mod malformed_protocol;
+mod reconnect;
+mod support;

--- a/crates/sui-rpc/tests/ledger_streams/malformed_protocol.rs
+++ b/crates/sui-rpc/tests/ledger_streams/malformed_protocol.rs
@@ -1,0 +1,138 @@
+use super::support::ScriptedStreamServer;
+use super::support::StreamScript;
+use super::support::bounded_event_request;
+use super::support::bytes;
+use super::support::event_identity_mask;
+use super::support::event_list_frame;
+use super::support::observed_client;
+use super::support::spawn_server;
+use futures::StreamExt;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+
+#[tokio::test]
+async fn list_rejects_first_item_at_exclusive_resume_bound() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([StreamScript::frames([
+        Ok(event_list_frame(Some(5), 5, None)),
+        Ok(event_list_frame(
+            None,
+            6,
+            Some(proto::QueryEndReason::CursorBound),
+        )),
+    ])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.list_events(
+        proto::ListEventsRequest::default()
+            .with_read_mask(event_identity_mask())
+            .with_options(proto::QueryOptions::default().with_after(bytes(5))),
+    );
+    futures::pin_mut!(stream);
+
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "List item cursor equals its exclusive request resume bound"
+    );
+    assert!(stream.next().await.is_none());
+    assert_eq!(server.state.lock().unwrap().calls, ["list_events"]);
+}
+
+#[tokio::test]
+async fn scan_limit_without_cursor_advancement_is_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        5,
+        Some(proto::QueryEndReason::ScanLimit),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.list_events(
+        proto::ListEventsRequest::default()
+            .with_read_mask(event_identity_mask())
+            .with_options(proto::QueryOptions::default().with_after(bytes(5))),
+    );
+    futures::pin_mut!(stream);
+
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "ScanLimit QueryEnd did not advance its cursor"
+    );
+    assert_eq!(server.state.lock().unwrap().calls, ["list_events"]);
+}
+
+#[tokio::test]
+async fn list_rejects_checkpoint_regression_retraction_and_duplicate_items() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let mut retracted_coverage = event_list_frame(None, 6, None);
+    retracted_coverage.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(event_list_frame(Some(4), 4, None)),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(event_list_frame(Some(6), 6, None)),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(event_list_frame(Some(5), 5, None)),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(retracted_coverage),
+        ]),
+    ]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let ascending = client.list_events(bounded_event_request());
+    futures::pin_mut!(ascending);
+    ascending.next().await.unwrap().unwrap();
+    let ascending_status = ascending.next().await.unwrap().unwrap_err();
+    assert_eq!(ascending_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        ascending_status.message(),
+        "List checkpoint coverage regressed"
+    );
+
+    let descending = client.list_events(
+        proto::ListEventsRequest::default()
+            .with_read_mask(event_identity_mask())
+            .with_start_checkpoint(0)
+            .with_end_checkpoint(10)
+            .with_options(
+                proto::QueryOptions::default().with_ordering(proto::Ordering::Descending),
+            ),
+    );
+    futures::pin_mut!(descending);
+    descending.next().await.unwrap().unwrap();
+    let descending_status = descending.next().await.unwrap().unwrap_err();
+    assert_eq!(descending_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        descending_status.message(),
+        "List checkpoint coverage regressed"
+    );
+
+    let duplicate = client.list_events(bounded_event_request());
+    futures::pin_mut!(duplicate);
+    duplicate.next().await.unwrap().unwrap();
+    let duplicate_status = duplicate.next().await.unwrap().unwrap_err();
+    assert_eq!(duplicate_status.code(), tonic::Code::DataLoss);
+    assert_eq!(duplicate_status.message(), "List item repeated its cursor");
+
+    let retraction = client.list_events(bounded_event_request());
+    futures::pin_mut!(retraction);
+    retraction.next().await.unwrap().unwrap();
+    let retraction_status = retraction.next().await.unwrap().unwrap_err();
+    assert_eq!(retraction_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        retraction_status.message(),
+        "List checkpoint coverage became unavailable"
+    );
+}

--- a/crates/sui-rpc/tests/ledger_streams/malformed_protocol.rs
+++ b/crates/sui-rpc/tests/ledger_streams/malformed_protocol.rs
@@ -2,12 +2,209 @@ use super::support::ScriptedStreamServer;
 use super::support::StreamScript;
 use super::support::bounded_event_request;
 use super::support::bytes;
+use super::support::checkpoint_identity_mask;
+use super::support::checkpoint_list_frame;
+use super::support::checkpoint_live_frame;
+use super::support::event_at;
 use super::support::event_identity_mask;
 use super::support::event_list_frame;
+use super::support::event_live_frame;
+use super::support::event_positioned_live_frame;
+use super::support::fast_config;
+use super::support::fast_list_config;
+use super::support::first_event_error;
+use super::support::first_list_event_error;
 use super::support::observed_client;
+use super::support::service_info;
 use super::support::spawn_server;
 use futures::StreamExt;
+use sui_rpc::client::CheckpointStreamRequest;
+use sui_rpc::client::CheckpointStreamStart;
+use sui_rpc::client::EventStreamRequest;
+use sui_rpc::client::EventStreamStart;
 use sui_rpc::proto::sui::rpc::v2 as proto;
+
+#[tokio::test]
+async fn malformed_list_and_subscription_frames_are_terminal_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(0)), Ok(service_info(0))]);
+    let missing_watermark = proto::ListEventsResponse::default();
+    let mut missing_cursor = proto::ListEventsResponse::default();
+    missing_cursor.watermark = Some(proto::Watermark::default());
+    let mut missing_reason = event_list_frame(None, 1, None);
+    missing_reason.end = Some(proto::QueryEnd::default());
+    let mut missing_item_identity = event_list_frame(Some(1), 1, None);
+    missing_item_identity.event.as_mut().unwrap().event_index = None;
+    server.push_event_lists([
+        StreamScript::frames([Ok(missing_watermark)]),
+        StreamScript::frames([Ok(missing_cursor)]),
+        StreamScript::frames([Ok(missing_reason)]),
+        StreamScript::frames([Ok(event_list_frame(
+            Some(1),
+            1,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            1,
+            Some(proto::QueryEndReason::ItemLimit),
+        ))]),
+        StreamScript::frames([]),
+        StreamScript::frames([Ok(missing_item_identity)]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+    ]);
+    let mut missing_subscription_identity =
+        event_positioned_live_frame(Some(event_at(1, 0, 0, "missing-index")), 1, 1);
+    missing_subscription_identity
+        .event
+        .as_mut()
+        .unwrap()
+        .event_index = None;
+    server.push_event_subscriptions([StreamScript::frames([Ok(missing_subscription_identity)])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    for expected_message in [
+        "List frame is missing its watermark",
+        "List watermark is missing its cursor",
+        "List QueryEnd has a missing or unknown reason",
+        "non-ItemLimit QueryEnd unexpectedly contains an item",
+        "ItemLimit QueryEnd is missing its item",
+        "List stream ended before its QueryEnd frame",
+    ] {
+        let status =
+            first_list_event_error(&client, bounded_event_request(), fast_list_config()).await;
+        assert_eq!(status.code(), tonic::Code::DataLoss);
+        assert_eq!(status.message(), expected_message);
+    }
+    let subscription_request = EventStreamRequest::new()
+        .with_read_mask(event_identity_mask())
+        .with_start(EventStreamStart::Resume(bytes(0)));
+    for _ in 0..2 {
+        let status = first_event_error(&client, subscription_request.clone(), fast_config()).await;
+        assert_eq!(status.code(), tonic::Code::DataLoss);
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_specific_malformed_frames_are_terminal_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(0))]);
+    let mut missing_list_checkpoint = checkpoint_list_frame(Some(1), 1, None);
+    missing_list_checkpoint
+        .watermark
+        .as_mut()
+        .unwrap()
+        .checkpoint = None;
+    server.push_checkpoint_lists([
+        StreamScript::frames([Ok(missing_list_checkpoint)]),
+        StreamScript::frames([Ok(checkpoint_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([Ok(checkpoint_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([Ok(checkpoint_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+    ]);
+    server.push_checkpoint_subscriptions([StreamScript::frames([Ok(
+        proto::SubscribeCheckpointsResponse::default(),
+    )])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let list_stream = client.list_checkpoints(
+        proto::ListCheckpointsRequest::default()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_end_checkpoint(2),
+    );
+    futures::pin_mut!(list_stream);
+    let list_status = list_stream.next().await.unwrap().unwrap_err();
+    assert_eq!(list_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        list_status.message(),
+        "List item watermark names no resumable position"
+    );
+
+    let terminal_stream = client.list_checkpoints(
+        proto::ListCheckpointsRequest::default()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_end_checkpoint(2),
+    );
+    futures::pin_mut!(terminal_stream);
+    let terminal_status = terminal_stream.next().await.unwrap().unwrap_err();
+    assert_eq!(terminal_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        terminal_status.message(),
+        "List CheckpointBound watermark does not match the requested bound"
+    );
+
+    let empty_bound_stream = client.list_checkpoints(
+        proto::ListCheckpointsRequest::default()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_end_checkpoint(0),
+    );
+    futures::pin_mut!(empty_bound_stream);
+    let empty_bound_status = empty_bound_stream.next().await.unwrap().unwrap_err();
+    assert_eq!(empty_bound_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        empty_bound_status.message(),
+        "List CheckpointBound watermark does not match the requested bound"
+    );
+
+    let subscription_stream = client.stream_checkpoints(
+        CheckpointStreamRequest::new()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_start(CheckpointStreamStart::Checkpoint(0)),
+    );
+    futures::pin_mut!(subscription_stream);
+    let subscription_progress = subscription_stream.next().await.unwrap().unwrap();
+    assert_eq!(subscription_progress.cursor, 0);
+    let subscription_status = subscription_stream.next().await.unwrap().unwrap_err();
+    assert_eq!(subscription_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        subscription_status.message(),
+        "checkpoint subscription frame is missing its cursor"
+    );
+}
+
+#[tokio::test]
+async fn unfiltered_checkpoint_progress_only_live_frame_is_terminal_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_checkpoint_subscriptions([StreamScript::frames([
+        Ok(checkpoint_live_frame(Some(0), 0)),
+        Ok(checkpoint_live_frame(None, 1)),
+        Ok(checkpoint_live_frame(Some(2), 2)),
+    ])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_checkpoints(
+        CheckpointStreamRequest::new().with_read_mask(checkpoint_identity_mask()),
+    );
+    futures::pin_mut!(stream);
+
+    let first = stream.next().await.unwrap().unwrap();
+    assert_eq!(first.cursor, 0);
+    assert_eq!(first.checkpoint.unwrap().sequence_number, Some(0),);
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "unfiltered checkpoint subscription frame is missing its checkpoint"
+    );
+    assert!(stream.next().await.is_none());
+}
 
 #[tokio::test]
 async fn list_rejects_first_item_at_exclusive_resume_bound() {
@@ -135,4 +332,39 @@ async fn list_rejects_checkpoint_regression_retraction_and_duplicate_items() {
         retraction_status.message(),
         "List checkpoint coverage became unavailable"
     );
+}
+
+#[tokio::test]
+async fn live_checkpoint_coverage_retraction_is_terminal_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(5)), Ok(service_info(5))]);
+    let mut retracted = event_live_frame(None, 6);
+    retracted.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_event_subscriptions([
+        StreamScript::frames([Ok(event_live_frame(None, 5))]),
+        StreamScript::frames([Ok(event_live_frame(None, 5)), Ok(retracted)]),
+    ]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        5,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new()
+            .with_read_mask(event_identity_mask())
+            .with_start(EventStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    stream.next().await.unwrap().unwrap();
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "subscription checkpoint coverage became unavailable"
+    );
+    assert!(stream.next().await.is_none());
 }

--- a/crates/sui-rpc/tests/ledger_streams/observability.rs
+++ b/crates/sui-rpc/tests/ledger_streams/observability.rs
@@ -1,0 +1,503 @@
+use super::support::ScriptedStreamServer;
+use super::support::StreamScript;
+use super::support::bytes;
+use super::support::event_identity_mask;
+use super::support::event_list_frame;
+use super::support::event_live_frame;
+use super::support::observed_client;
+use super::support::recording_config;
+use super::support::service_info;
+use super::support::spawn_server;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use std::time::Duration;
+use std::time::Instant;
+use sui_rpc::client::EventStreamRequest;
+use sui_rpc::client::EventStreamStart;
+use sui_rpc::client::LedgerStreamConfig;
+use sui_rpc::client::LedgerStreamEvent;
+use sui_rpc::client::LedgerStreamFamily;
+use sui_rpc::client::LedgerStreamOperation;
+use sui_rpc::client::LedgerStreamStage;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+use tokio::sync::mpsc;
+
+#[tokio::test(start_paused = true)]
+async fn observer_reports_rpc_response_context_and_elapsed_time() {
+    const REAL_TIME_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
+
+    async fn receive_call_without_advancing_time(
+        calls: &mut mpsc::UnboundedReceiver<&'static str>,
+        expected_call: &str,
+    ) -> &'static str {
+        let deadline = Instant::now() + REAL_TIME_WAIT_TIMEOUT;
+        loop {
+            match calls.try_recv() {
+                Ok(call) => return call,
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for {expected_call} scripted RPC call"
+                    );
+                    tokio::task::yield_now().await;
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    panic!(
+                        "scripted call channel closed while waiting for {expected_call} RPC call"
+                    )
+                }
+            }
+        }
+    }
+
+    async fn receive_observer_event_without_advancing_time(
+        observer_events: &mut mpsc::UnboundedReceiver<LedgerStreamEvent>,
+        expected_event: &str,
+    ) -> LedgerStreamEvent {
+        let deadline = Instant::now() + REAL_TIME_WAIT_TIMEOUT;
+        loop {
+            match observer_events.try_recv() {
+                Ok(event) => return event,
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for {expected_event} observer event"
+                    );
+                    tokio::task::yield_now().await;
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    panic!("observer event channel closed while waiting for {expected_event} event")
+                }
+            }
+        }
+    }
+
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.set_response_delay(Duration::from_secs(1));
+    server.push_service_infos([Ok(service_info(0))]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        0,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([StreamScript::Channel(live_rx)]);
+    let address = spawn_server(server).await;
+    let (client, observations) = observed_client(address);
+    let (config, mut observer_events) = recording_config(LedgerStreamConfig::default());
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new()
+                    .with_read_mask(event_identity_mask())
+                    .with_start(EventStreamStart::Checkpoint(0)),
+                config,
+            )
+            .take(3)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(
+        receive_call_without_advancing_time(&mut calls, "GetServiceInfo").await,
+        "get_service_info"
+    );
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    match receive_observer_event_without_advancing_time(
+        &mut observer_events,
+        "GetServiceInfo RpcResponse",
+    )
+    .await
+    {
+        LedgerStreamEvent::RpcResponse {
+            family,
+            operation,
+            stage,
+            code,
+            elapsed,
+            ..
+        } => {
+            assert_eq!(family, LedgerStreamFamily::Event);
+            assert_eq!(operation, LedgerStreamOperation::GetServiceInfo);
+            assert_eq!(stage, LedgerStreamStage::InitialReplay);
+            assert_eq!(code, tonic::Code::Ok);
+            assert_eq!(elapsed, Duration::from_secs(1));
+        }
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+
+    assert_eq!(
+        receive_call_without_advancing_time(&mut calls, "ListEvents").await,
+        "list_events"
+    );
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    match receive_observer_event_without_advancing_time(
+        &mut observer_events,
+        "ListEvents RpcResponse",
+    )
+    .await
+    {
+        LedgerStreamEvent::RpcResponse {
+            family,
+            operation,
+            stage,
+            code,
+            elapsed,
+            ..
+        } => {
+            assert_eq!(family, LedgerStreamFamily::Event);
+            assert_eq!(operation, LedgerStreamOperation::List);
+            assert_eq!(stage, LedgerStreamStage::InitialReplay);
+            assert_eq!(code, tonic::Code::Ok);
+            assert_eq!(elapsed, Duration::from_secs(1));
+        }
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+
+    assert_eq!(
+        receive_call_without_advancing_time(&mut calls, "SubscribeEvents").await,
+        "subscribe_events"
+    );
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    match receive_observer_event_without_advancing_time(
+        &mut observer_events,
+        "SubscribeEvents RpcResponse",
+    )
+    .await
+    {
+        LedgerStreamEvent::RpcResponse {
+            family,
+            operation,
+            stage,
+            code,
+            elapsed,
+            ..
+        } => {
+            assert_eq!(family, LedgerStreamFamily::Event);
+            assert_eq!(operation, LedgerStreamOperation::Subscribe);
+            assert_eq!(stage, LedgerStreamStage::LiveSubscription);
+            assert_eq!(code, tonic::Code::Ok);
+            assert_eq!(elapsed, Duration::from_secs(1));
+        }
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+
+    live_tx.send(Ok(event_live_frame(None, 0))).unwrap();
+    live_tx.send(Ok(event_live_frame(Some(1), 1))).unwrap();
+    live_tx.send(Ok(event_live_frame(None, 2))).unwrap();
+    let collector_deadline = Instant::now() + REAL_TIME_WAIT_TIMEOUT;
+    while !collector.is_finished() {
+        assert!(
+            Instant::now() < collector_deadline,
+            "timed out waiting for RPC response context collector"
+        );
+        tokio::task::yield_now().await;
+    }
+    let frames = collector.await.unwrap().unwrap();
+    drop(live_tx);
+    assert_eq!(frames.len(), 3);
+    assert!(frames[0].event.is_none());
+    assert_eq!(frames[0].cursor, bytes(0));
+    assert_eq!(
+        frames[1].event.as_ref().unwrap().event_type.as_deref(),
+        Some("event-1")
+    );
+    assert_eq!(frames[1].cursor, bytes(1));
+    assert!(frames[2].event.is_none());
+    assert_eq!(frames[2].cursor, bytes(2));
+    assert!(observer_events.try_recv().is_err());
+
+    let observations = observations.lock().unwrap();
+    assert_eq!(
+        observations
+            .iter()
+            .map(|observation| observation.path.rsplit('/').next().unwrap())
+            .collect::<Vec<_>>(),
+        ["GetServiceInfo", "ListEvents", "SubscribeEvents"]
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn observer_reports_independent_retry_episodes() {
+    const REAL_TIME_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
+
+    async fn receive_call_without_advancing_time(
+        calls: &mut mpsc::UnboundedReceiver<&'static str>,
+        expected_call: &str,
+    ) -> &'static str {
+        let deadline = Instant::now() + REAL_TIME_WAIT_TIMEOUT;
+        loop {
+            match calls.try_recv() {
+                Ok(call) => return call,
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for {expected_call} scripted RPC call"
+                    );
+                    tokio::task::yield_now().await;
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    panic!(
+                        "scripted call channel closed while waiting for {expected_call} RPC call"
+                    )
+                }
+            }
+        }
+    }
+
+    async fn receive_observer_event_without_advancing_time(
+        observer_events: &mut mpsc::UnboundedReceiver<LedgerStreamEvent>,
+        operation: LedgerStreamOperation,
+        expected_event: &str,
+    ) -> LedgerStreamEvent {
+        let deadline = Instant::now() + REAL_TIME_WAIT_TIMEOUT;
+        loop {
+            match observer_events.try_recv() {
+                Ok(event) => return event,
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for {expected_event} observer event for {operation:?}"
+                    );
+                    tokio::task::yield_now().await;
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    panic!(
+                        "observer event channel closed while waiting for {expected_event} event for {operation:?}"
+                    )
+                }
+            }
+        }
+    }
+
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([
+        Err(tonic::Status::unavailable("service info failed")),
+        Ok(service_info(0)),
+        Ok(service_info(0)),
+    ]);
+    server.push_event_lists([
+        StreamScript::DispatchError(tonic::Status::unavailable("list failed")),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+    ]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([
+        StreamScript::DispatchError(tonic::Status::unavailable("subscribe failed")),
+        StreamScript::Channel(live_rx),
+    ]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = LedgerStreamConfig::default();
+    config.base_retry_delay = Duration::from_secs(1);
+    config.max_retry_delay = Duration::from_secs(1);
+    config.retry_jitter = Duration::ZERO;
+    let (config, mut observer_events) = recording_config(config);
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new()
+                    .with_read_mask(event_identity_mask())
+                    .with_start(EventStreamStart::Checkpoint(0)),
+                config,
+            )
+            .take(2)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    for (call, operation, stage, message) in [
+        (
+            "get_service_info",
+            LedgerStreamOperation::GetServiceInfo,
+            LedgerStreamStage::InitialReplay,
+            "service info failed",
+        ),
+        (
+            "list_events",
+            LedgerStreamOperation::List,
+            LedgerStreamStage::InitialReplay,
+            "list failed",
+        ),
+        (
+            "subscribe_events",
+            LedgerStreamOperation::Subscribe,
+            LedgerStreamStage::LiveSubscription,
+            "subscribe failed",
+        ),
+    ] {
+        assert_eq!(
+            receive_call_without_advancing_time(&mut calls, call).await,
+            call
+        );
+        match receive_observer_event_without_advancing_time(
+            &mut observer_events,
+            operation,
+            "failed RpcResponse",
+        )
+        .await
+        {
+            LedgerStreamEvent::RpcResponse {
+                family,
+                operation: observed_operation,
+                stage: observed_stage,
+                code,
+                elapsed,
+                ..
+            } => {
+                assert_eq!(family, LedgerStreamFamily::Event);
+                assert_eq!(observed_operation, operation);
+                assert_eq!(observed_stage, stage);
+                assert_eq!(code, tonic::Code::Unavailable);
+                assert_eq!(elapsed, Duration::ZERO);
+            }
+            event => panic!("unexpected observer event: {event:?}"),
+        }
+        match receive_observer_event_without_advancing_time(
+            &mut observer_events,
+            operation,
+            "RetryScheduled",
+        )
+        .await
+        {
+            LedgerStreamEvent::RetryScheduled {
+                family,
+                operation: observed_operation,
+                stage: observed_stage,
+                status,
+                consecutive_failures,
+                delay,
+                ..
+            } => {
+                assert_eq!(family, LedgerStreamFamily::Event);
+                assert_eq!(observed_operation, operation);
+                assert_eq!(observed_stage, stage);
+                assert_eq!(status.code(), tonic::Code::Unavailable);
+                assert_eq!(status.message(), message);
+                assert_eq!(consecutive_failures, 1);
+                assert_eq!(delay, Duration::from_secs(1));
+            }
+            event => panic!("unexpected observer event: {event:?}"),
+        }
+        tokio::task::yield_now().await;
+        assert!(calls.try_recv().is_err());
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        if operation == LedgerStreamOperation::Subscribe {
+            assert_eq!(
+                receive_call_without_advancing_time(&mut calls, "get_service_info").await,
+                "get_service_info"
+            );
+            match receive_observer_event_without_advancing_time(
+                &mut observer_events,
+                LedgerStreamOperation::GetServiceInfo,
+                "recovery-tip RpcResponse",
+            )
+            .await
+            {
+                LedgerStreamEvent::RpcResponse {
+                    family,
+                    operation: observed_operation,
+                    stage,
+                    code,
+                    elapsed,
+                    ..
+                } => {
+                    assert_eq!(family, LedgerStreamFamily::Event);
+                    assert_eq!(observed_operation, LedgerStreamOperation::GetServiceInfo);
+                    assert_eq!(stage, LedgerStreamStage::GapRecovery);
+                    assert_eq!(code, tonic::Code::Ok);
+                    assert_eq!(elapsed, Duration::ZERO);
+                }
+                event => panic!("unexpected observer event: {event:?}"),
+            }
+            assert_eq!(
+                receive_call_without_advancing_time(&mut calls, call).await,
+                call
+            );
+        } else {
+            assert_eq!(
+                receive_call_without_advancing_time(&mut calls, call).await,
+                call
+            );
+        }
+        match receive_observer_event_without_advancing_time(
+            &mut observer_events,
+            operation,
+            "successful RpcResponse",
+        )
+        .await
+        {
+            LedgerStreamEvent::RpcResponse {
+                family,
+                operation: observed_operation,
+                stage: observed_stage,
+                code,
+                elapsed,
+                ..
+            } => {
+                assert_eq!(family, LedgerStreamFamily::Event);
+                assert_eq!(observed_operation, operation);
+                assert_eq!(observed_stage, stage);
+                assert_eq!(code, tonic::Code::Ok);
+                assert_eq!(elapsed, Duration::ZERO);
+            }
+            event => panic!("unexpected observer event: {event:?}"),
+        }
+        if operation == LedgerStreamOperation::Subscribe {
+            live_tx.send(Ok(event_live_frame(None, 0))).unwrap();
+        }
+        match receive_observer_event_without_advancing_time(
+            &mut observer_events,
+            operation,
+            "RetryRecovered",
+        )
+        .await
+        {
+            LedgerStreamEvent::RetryRecovered {
+                family,
+                operation: observed_operation,
+                started_in,
+                consecutive_failures,
+                elapsed,
+                ..
+            } => {
+                assert_eq!(family, LedgerStreamFamily::Event);
+                assert_eq!(observed_operation, operation);
+                assert_eq!(started_in, stage);
+                assert_eq!(consecutive_failures, 1);
+                assert_eq!(elapsed, Duration::from_secs(1));
+            }
+            event => panic!("unexpected observer event: {event:?}"),
+        }
+        if operation == LedgerStreamOperation::Subscribe {
+            live_tx.send(Ok(event_live_frame(Some(1), 1))).unwrap();
+        }
+    }
+
+    let collector_deadline = Instant::now() + REAL_TIME_WAIT_TIMEOUT;
+    while !collector.is_finished() {
+        assert!(
+            Instant::now() < collector_deadline,
+            "timed out waiting for independent retry episode collector"
+        );
+        tokio::task::yield_now().await;
+    }
+    let frames = collector.await.unwrap().unwrap();
+    drop(live_tx);
+    assert_eq!(frames.len(), 2);
+    assert!(frames[0].event.is_none());
+    assert_eq!(frames[0].cursor, bytes(0));
+    assert_eq!(
+        frames[1].event.as_ref().unwrap().event_type.as_deref(),
+        Some("event-1")
+    );
+    assert_eq!(frames[1].cursor, bytes(1));
+    assert!(observer_events.try_recv().is_err());
+}

--- a/crates/sui-rpc/tests/ledger_streams/polling.rs
+++ b/crates/sui-rpc/tests/ledger_streams/polling.rs
@@ -1,0 +1,1277 @@
+use super::support::ScriptedStreamServer;
+use super::support::StreamScript;
+use super::support::bytes;
+use super::support::checkpoint_identity_mask;
+use super::support::checkpoint_list_frame;
+use super::support::event_identity_mask;
+use super::support::event_list_frame;
+use super::support::event_live_frame;
+use super::support::event_positioned_list_frame;
+use super::support::fast_config;
+use super::support::fast_list_config;
+use super::support::next_scripted_call;
+use super::support::observed_client;
+use super::support::recording_config;
+use super::support::service_info;
+use super::support::spawn_ledger_only_server;
+use super::support::spawn_server;
+use super::support::transaction_identity_mask;
+use super::support::transaction_list_frame;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use std::time::Duration;
+use sui_rpc::client::CheckpointStreamRequest;
+use sui_rpc::client::CheckpointStreamStart;
+use sui_rpc::client::Delivery;
+use sui_rpc::client::EventStreamRequest;
+use sui_rpc::client::EventStreamStart;
+use sui_rpc::client::LedgerStreamEvent;
+use sui_rpc::client::LedgerStreamFamily;
+use sui_rpc::client::LedgerStreamOperation;
+use sui_rpc::client::LedgerStreamStage;
+use sui_rpc::client::TransactionStreamRequest;
+use sui_rpc::client::TransactionStreamStart;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn poll_suppresses_baseline_for_all_families() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos(
+        [5, 6, 5, 6, 5, 6]
+            .into_iter()
+            .map(|height| Ok(service_info(height))),
+    );
+    server.push_checkpoint_lists([
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(5), 5, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(6), 6, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                6,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    server.push_transaction_lists([
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(5), 5, None)),
+            Ok(transaction_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(6), 6, None)),
+            Ok(transaction_list_frame(
+                None,
+                6,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(event_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(6), 6, None)),
+            Ok(event_list_frame(
+                None,
+                6,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_ledger_only_server(server.clone()).await;
+    let (client, observations) = observed_client(address);
+    let mut config = fast_config();
+    config.ledger_tip_poll_interval = Duration::from_millis(1);
+    let (config, mut observer_events) = recording_config(config);
+
+    let checkpoint_ids = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_checkpoints_with_config(
+                CheckpointStreamRequest::new()
+                    .with_read_mask(prost_types::FieldMask {
+                        paths: vec!["sequence_number".to_owned()],
+                    })
+                    .with_filter(proto::TransactionFilter::default())
+                    .with_delivery(Delivery::Poll),
+                config.clone(),
+            )
+            .try_filter_map(|frame| async move {
+                Ok(frame
+                    .checkpoint
+                    .and_then(|checkpoint| checkpoint.sequence_number))
+            })
+            .take(1)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for polled checkpoint")
+    .unwrap();
+    assert_eq!(checkpoint_ids, [6]);
+
+    let transaction_ids = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_transactions_with_config(
+                TransactionStreamRequest::new()
+                    .with_read_mask(transaction_identity_mask())
+                    .with_filter(proto::TransactionFilter::default())
+                    .with_delivery(Delivery::Poll),
+                config.clone(),
+            )
+            .try_filter_map(|frame| async move {
+                Ok(frame
+                    .transaction
+                    .and_then(|transaction| transaction.checkpoint))
+            })
+            .take(1)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for polled transaction")
+    .unwrap();
+    assert_eq!(transaction_ids, [6]);
+
+    let event_ids = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new()
+                    .with_read_mask(event_identity_mask())
+                    .with_filter(proto::EventFilter::default())
+                    .with_delivery(Delivery::Poll),
+                config,
+            )
+            .try_filter_map(
+                |frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) },
+            )
+            .take(1)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for polled event")
+    .unwrap();
+    assert_eq!(event_ids, [6]);
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.calls,
+        [
+            "get_service_info",
+            "list_checkpoints",
+            "get_service_info",
+            "list_checkpoints",
+            "get_service_info",
+            "list_transactions",
+            "get_service_info",
+            "list_transactions",
+            "get_service_info",
+            "list_events",
+            "get_service_info",
+            "list_events",
+        ]
+    );
+    assert_eq!(state.checkpoint_requests[0].body.start_checkpoint, Some(5));
+    assert_eq!(state.checkpoint_requests[0].body.end_checkpoint, Some(6));
+    assert_eq!(state.transaction_requests[0].body.start_checkpoint, Some(5));
+    assert_eq!(state.transaction_requests[0].body.end_checkpoint, Some(6));
+    assert_eq!(state.event_requests[0].body.start_checkpoint, Some(5));
+    assert_eq!(state.event_requests[0].body.end_checkpoint, Some(6));
+    assert_eq!(
+        state.checkpoint_requests[0].body.read_mask,
+        Some(prost_types::FieldMask {
+            paths: vec!["sequence_number".to_owned()],
+        })
+    );
+    assert_eq!(
+        state.checkpoint_requests[0].body.filter,
+        Some(proto::TransactionFilter::default())
+    );
+    assert_eq!(
+        state.transaction_requests[0].body.read_mask,
+        Some(prost_types::FieldMask {
+            paths: vec!["checkpoint".to_owned(), "transaction_index".to_owned()],
+        })
+    );
+    assert_eq!(
+        state.transaction_requests[0].body.filter,
+        Some(proto::TransactionFilter::default())
+    );
+    assert_eq!(
+        state.event_requests[0].body.read_mask,
+        Some(prost_types::FieldMask {
+            paths: vec![
+                "checkpoint".to_owned(),
+                "transaction_index".to_owned(),
+                "event_index".to_owned(),
+            ],
+        })
+    );
+    assert_eq!(
+        state.event_requests[0].body.filter,
+        Some(proto::EventFilter::default())
+    );
+    for options in [
+        state.checkpoint_requests[0].body.options.as_ref().unwrap(),
+        state.transaction_requests[0].body.options.as_ref().unwrap(),
+        state.event_requests[0].body.options.as_ref().unwrap(),
+    ] {
+        assert!(options.limit.is_none());
+        assert!(options.ordering.is_none());
+    }
+    drop(state);
+
+    let observations = observations.lock().unwrap();
+    let rpc_names = observations
+        .iter()
+        .map(|observation| observation.path.rsplit('/').next().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        rpc_names,
+        [
+            "GetServiceInfo",
+            "ListCheckpoints",
+            "GetServiceInfo",
+            "ListCheckpoints",
+            "GetServiceInfo",
+            "ListTransactions",
+            "GetServiceInfo",
+            "ListTransactions",
+            "GetServiceInfo",
+            "ListEvents",
+            "GetServiceInfo",
+            "ListEvents",
+        ]
+    );
+    assert!(
+        observations
+            .iter()
+            .all(|observation| !observation.path.contains("Subscribe"))
+    );
+    drop(observations);
+
+    let mut events = Vec::new();
+    while let Ok(event) = observer_events.try_recv() {
+        events.push(event);
+    }
+    let families = [
+        LedgerStreamFamily::Checkpoint,
+        LedgerStreamFamily::Transaction,
+        LedgerStreamFamily::Event,
+    ];
+    assert_eq!(events.len(), families.len() * 4);
+    for (family_events, family) in events.chunks_exact(4).zip(families) {
+        assert!(matches!(
+            &family_events[0],
+            LedgerStreamEvent::RpcResponse {
+                family: observed_family,
+                operation: LedgerStreamOperation::GetServiceInfo,
+                stage: LedgerStreamStage::PollingBaseline,
+                code: tonic::Code::Ok,
+                ..
+            } if *observed_family == family
+        ));
+        assert!(matches!(
+            &family_events[1],
+            LedgerStreamEvent::RpcResponse {
+                family: observed_family,
+                operation: LedgerStreamOperation::List,
+                stage: LedgerStreamStage::PollingBaseline,
+                code: tonic::Code::Ok,
+                ..
+            } if *observed_family == family
+        ));
+        assert!(matches!(
+            &family_events[2],
+            LedgerStreamEvent::RpcResponse {
+                family: observed_family,
+                operation: LedgerStreamOperation::GetServiceInfo,
+                stage: LedgerStreamStage::PollingTail,
+                code: tonic::Code::Ok,
+                ..
+            } if *observed_family == family
+        ));
+        assert!(matches!(
+            &family_events[3],
+            LedgerStreamEvent::RpcResponse {
+                family: observed_family,
+                operation: LedgerStreamOperation::List,
+                stage: LedgerStreamStage::PollingTail,
+                code: tonic::Code::Ok,
+                ..
+            } if *observed_family == family
+        ));
+    }
+}
+
+#[tokio::test]
+async fn tip_poll_and_tip_subscribe_share_the_frame_contract() {
+    let (subscribe_server, _calls) = ScriptedStreamServer::new();
+    subscribe_server.push_event_subscriptions([StreamScript::frames([
+        Ok(event_live_frame(None, 5)),
+        Ok(event_live_frame(Some(6), 6)),
+    ])]);
+    let address = spawn_server(subscribe_server).await;
+    let (subscribe_client, _observations) = observed_client(address);
+    let subscribe_frames = subscribe_client
+        .stream_events(EventStreamRequest::new().with_read_mask(event_identity_mask()))
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    let (poll_server, _calls) = ScriptedStreamServer::new();
+    poll_server.push_service_infos([
+        Ok(service_info(5)),
+        Ok(service_info(6)),
+        Ok(service_info(7)),
+    ]);
+    poll_server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(event_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(6), 6, None)),
+            Ok(event_list_frame(
+                None,
+                6,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            7,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+    ]);
+    let address = spawn_ledger_only_server(poll_server).await;
+    let (poll_client, _observations) = observed_client(address);
+    let mut config = fast_config();
+    config.ledger_tip_poll_interval = Duration::from_millis(1);
+    let poll_frames = poll_client
+        .stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_delivery(Delivery::Poll),
+            config,
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    // Both deliveries use the same resumable frame contract, but Poll suppresses its tip baseline,
+    // so frame ordering may differ.
+    for frames in [&subscribe_frames, &poll_frames] {
+        assert_eq!(frames.len(), 2);
+        for frame in frames.iter() {
+            assert!(!frame.cursor.is_empty());
+        }
+        let item_checkpoints: Vec<_> = frames
+            .iter()
+            .filter_map(|frame| frame.event.as_ref())
+            .map(|event| event.checkpoint)
+            .collect();
+        assert_eq!(item_checkpoints, [Some(6)]);
+    }
+}
+
+#[tokio::test]
+async fn tip_poll_rejects_maximum_service_checkpoint_before_list() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(u64::MAX))]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_checkpoints(
+        CheckpointStreamRequest::new()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_delivery(Delivery::Poll),
+    );
+    futures::pin_mut!(stream);
+    let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for live-tip overflow")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::OutOfRange);
+    assert_eq!(
+        status.message(),
+        "checkpoint height cannot be converted to an exclusive end bound"
+    );
+    assert_eq!(server.state.lock().unwrap().calls, ["get_service_info"]);
+}
+
+#[tokio::test]
+async fn in_body_unimplemented_is_terminal() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_subscriptions([StreamScript::frames([Err(tonic::Status::unimplemented(
+        "subscription body unavailable",
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream =
+        client.stream_events(EventStreamRequest::new().with_read_mask(event_identity_mask()));
+    futures::pin_mut!(stream);
+    let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for in-body Unimplemented")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    assert_eq!(server.state.lock().unwrap().calls, ["subscribe_events"]);
+}
+
+#[tokio::test]
+async fn future_lower_bound_polls_service_info_before_listing() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([
+        Ok(service_info(5)),
+        Ok(service_info(99)),
+        Ok(service_info(100)),
+    ]);
+    server.push_event_lists([StreamScript::frames([
+        Ok(event_list_frame(Some(100), 100, None)),
+        Ok(event_list_frame(
+            None,
+            100,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    live_tx.send(Ok(event_live_frame(None, 100))).unwrap();
+    live_tx.send(Ok(event_live_frame(Some(101), 101))).unwrap();
+    server.push_event_subscriptions([StreamScript::Channel(live_rx)]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = fast_config();
+    config.ledger_tip_poll_interval = Duration::from_millis(10);
+
+    let body = EventStreamRequest::new()
+        .with_read_mask(event_identity_mask())
+        .with_start(EventStreamStart::Checkpoint(100));
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(body, config)
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.checkpoint.unwrap()))
+            })
+            .take(2)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(server.state.lock().unwrap().event_requests.len(), 0);
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(server.state.lock().unwrap().event_requests.len(), 0);
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+    assert_eq!(collector.await.unwrap().unwrap(), [100, 101]);
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.calls,
+        [
+            "get_service_info",
+            "get_service_info",
+            "get_service_info",
+            "list_events",
+            "subscribe_events"
+        ]
+    );
+    assert_eq!(state.event_requests.len(), 1);
+    assert_eq!(state.event_requests[0].body.start_checkpoint, Some(100));
+    assert_eq!(state.event_requests[0].body.end_checkpoint, Some(101));
+}
+
+#[tokio::test]
+async fn list_page_limit_applies_to_internal_lists_only() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos(
+        [2, 2, 2, 4, 2, 2, 2, 4, 2, 2, 2, 4]
+            .into_iter()
+            .map(|height| Ok(service_info(height))),
+    );
+    server.push_checkpoint_lists([
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(1), 1, None)),
+            Ok(checkpoint_list_frame(Some(2), 2, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(3), 3, None)),
+            Ok(checkpoint_list_frame(Some(4), 4, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                4,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    server.push_transaction_lists([
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(1), 1, None)),
+            Ok(transaction_list_frame(Some(2), 2, None)),
+            Ok(transaction_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(3), 3, None)),
+            Ok(transaction_list_frame(Some(4), 4, None)),
+            Ok(transaction_list_frame(
+                None,
+                4,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(1), 1, None)),
+            Ok(event_list_frame(Some(2), 2, None)),
+            Ok(event_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(3), 3, None)),
+            Ok(event_list_frame(Some(4), 4, None)),
+            Ok(event_list_frame(
+                None,
+                4,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            4,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+    ]);
+    let address = spawn_ledger_only_server(server.clone()).await;
+    let (client, observations) = observed_client(address);
+    let mut config = fast_config();
+    config.ledger_tip_poll_interval = Duration::from_millis(10);
+    config.list_page_limit = Some(2);
+
+    let checkpoint_request = CheckpointStreamRequest::new()
+        .with_read_mask(checkpoint_identity_mask())
+        .with_start(CheckpointStreamStart::Checkpoint(1))
+        .with_delivery(Delivery::Poll);
+    let checkpoint_client = client.clone();
+    let checkpoint_config = config.clone();
+    let checkpoints = tokio::spawn(async move {
+        checkpoint_client
+            .stream_checkpoints_with_config(checkpoint_request, checkpoint_config)
+            .try_filter_map(|frame| async move {
+                Ok(frame
+                    .checkpoint
+                    .map(|checkpoint| checkpoint.sequence_number.unwrap()))
+            })
+            .take(4)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+    assert_eq!(checkpoints.await.unwrap().unwrap(), [1, 2, 3, 4]);
+
+    let transaction_request = TransactionStreamRequest::new()
+        .with_read_mask(transaction_identity_mask())
+        .with_start(TransactionStreamStart::Checkpoint(1))
+        .with_delivery(Delivery::Poll);
+    let transaction_client = client.clone();
+    let transaction_config = config.clone();
+    let transactions = tokio::spawn(async move {
+        transaction_client
+            .stream_transactions_with_config(transaction_request, transaction_config)
+            .try_filter_map(|frame| async move {
+                Ok(frame
+                    .transaction
+                    .map(|transaction| transaction.checkpoint.unwrap()))
+            })
+            .take(4)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+    assert_eq!(transactions.await.unwrap().unwrap(), [1, 2, 3, 4]);
+
+    let event_request = EventStreamRequest::new()
+        .with_read_mask(event_identity_mask())
+        .with_start(EventStreamStart::Checkpoint(1))
+        .with_delivery(Delivery::Poll);
+    let event_client = client.clone();
+    let event_config = config.clone();
+    let events = tokio::spawn(async move {
+        event_client
+            .stream_events_with_config(event_request, event_config)
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.checkpoint.unwrap()))
+            })
+            .take(4)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+    assert_eq!(events.await.unwrap().unwrap(), [1, 2, 3, 4]);
+
+    client
+        .list_events_with_config(
+            proto::ListEventsRequest::default()
+                .with_options(proto::QueryOptions::default().with_limit(7)),
+            fast_list_config(),
+        )
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.checkpoint_requests.len(), 2);
+    assert_eq!(state.transaction_requests.len(), 2);
+    assert_eq!(state.event_requests.len(), 3);
+    assert_eq!(state.service_info_requests.len(), 12);
+    for request in [
+        &state.checkpoint_requests[0].body,
+        &state.checkpoint_requests[1].body,
+    ] {
+        assert_eq!(request.options.as_ref().unwrap().limit, Some(2));
+    }
+    for request in [
+        &state.transaction_requests[0].body,
+        &state.transaction_requests[1].body,
+    ] {
+        assert_eq!(request.options.as_ref().unwrap().limit, Some(2));
+    }
+    for request in [&state.event_requests[0].body, &state.event_requests[1].body] {
+        assert_eq!(request.options.as_ref().unwrap().limit, Some(2));
+    }
+    assert_eq!(
+        state.event_requests[2].body.options.as_ref().unwrap().limit,
+        Some(7)
+    );
+    assert_eq!(state.checkpoint_requests[1].body.start_checkpoint, Some(3));
+    assert_eq!(state.checkpoint_requests[1].body.end_checkpoint, Some(5));
+    assert_eq!(
+        state.transaction_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .after,
+        Some(bytes(2))
+    );
+    assert_eq!(state.transaction_requests[1].body.end_checkpoint, Some(5));
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(2))
+    );
+    assert_eq!(state.event_requests[1].body.end_checkpoint, Some(5));
+    assert!(state.checkpoint_subscriptions.is_empty());
+    assert!(state.transaction_subscriptions.is_empty());
+    assert!(state.event_subscriptions.is_empty());
+    assert!(
+        observations
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|observation| !observation.path.contains("Subscribe"))
+    );
+}
+
+#[tokio::test]
+async fn dispatch_unimplemented_is_terminal_for_ledger_streams() {
+    let (checkpoint_server, _calls) = ScriptedStreamServer::new();
+    checkpoint_server.push_service_infos([Ok(service_info(2))]);
+    checkpoint_server.push_checkpoint_lists([StreamScript::frames([
+        Ok(checkpoint_list_frame(Some(2), 2, None)),
+        Ok(checkpoint_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    checkpoint_server.push_checkpoint_subscriptions([StreamScript::DispatchError(
+        tonic::Status::unimplemented("checkpoint subscription unavailable"),
+    )]);
+    let address = spawn_server(checkpoint_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut checkpoint_events) = recording_config(fast_config());
+    let stream = client.stream_checkpoints_with_config(
+        CheckpointStreamRequest::new()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_start(CheckpointStreamStart::Checkpoint(0)),
+        config,
+    );
+    futures::pin_mut!(stream);
+    assert_eq!(
+        stream
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .checkpoint
+            .unwrap()
+            .sequence_number,
+        Some(2)
+    );
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    assert_eq!(status.message(), "checkpoint subscription unavailable");
+    assert!(stream.next().await.is_none());
+    {
+        let state = checkpoint_server.state.lock().unwrap();
+        assert_eq!(
+            state.calls,
+            [
+                "get_service_info",
+                "list_checkpoints",
+                "subscribe_checkpoints"
+            ]
+        );
+        assert_eq!(state.service_info_requests.len(), 1);
+        assert_eq!(state.checkpoint_requests.len(), 1);
+    }
+    let mut events = Vec::new();
+    while let Ok(event) = checkpoint_events.try_recv() {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 4);
+    assert!(matches!(
+        &events[0],
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Checkpoint,
+            operation: LedgerStreamOperation::GetServiceInfo,
+            stage: LedgerStreamStage::InitialReplay,
+            code: tonic::Code::Ok,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[1],
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Checkpoint,
+            operation: LedgerStreamOperation::List,
+            stage: LedgerStreamStage::InitialReplay,
+            code: tonic::Code::Ok,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[2],
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Checkpoint,
+            operation: LedgerStreamOperation::Subscribe,
+            stage: LedgerStreamStage::LiveSubscription,
+            code: tonic::Code::Unimplemented,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[3],
+        LedgerStreamEvent::TerminalError {
+            family: LedgerStreamFamily::Checkpoint,
+            status,
+            ..
+        } if status.code() == tonic::Code::Unimplemented
+            && status.message() == "checkpoint subscription unavailable"
+    ));
+
+    let (event_server, _calls) = ScriptedStreamServer::new();
+    event_server.push_event_subscriptions([StreamScript::DispatchError(
+        tonic::Status::unimplemented("event subscription unavailable"),
+    )]);
+    let address = spawn_server(event_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut event_events) = recording_config(fast_config());
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new().with_read_mask(event_identity_mask()),
+        config,
+    );
+    futures::pin_mut!(stream);
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unimplemented);
+    assert_eq!(status.message(), "event subscription unavailable");
+    assert!(stream.next().await.is_none());
+    {
+        let state = event_server.state.lock().unwrap();
+        assert_eq!(state.calls, ["subscribe_events"]);
+        assert!(state.service_info_requests.is_empty());
+        assert!(state.event_requests.is_empty());
+    }
+    let mut events = Vec::new();
+    while let Ok(event) = event_events.try_recv() {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0],
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Event,
+            operation: LedgerStreamOperation::Subscribe,
+            stage: LedgerStreamStage::LiveTipStartup,
+            code: tonic::Code::Unimplemented,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[1],
+        LedgerStreamEvent::TerminalError {
+            family: LedgerStreamFamily::Event,
+            status,
+            ..
+        } if status.code() == tonic::Code::Unimplemented
+            && status.message() == "event subscription unavailable"
+    ));
+
+    let (permission_server, _calls) = ScriptedStreamServer::new();
+    permission_server.push_service_infos([Ok(service_info(2))]);
+    permission_server.push_checkpoint_lists([StreamScript::frames([
+        Ok(checkpoint_list_frame(Some(2), 2, None)),
+        Ok(checkpoint_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    permission_server.push_checkpoint_subscriptions([StreamScript::DispatchError(
+        tonic::Status::permission_denied("subscription denied"),
+    )]);
+    let address = spawn_server(permission_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut permission_events) = recording_config(fast_config());
+    let stream = client.stream_checkpoints_with_config(
+        CheckpointStreamRequest::new()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_start(CheckpointStreamStart::Checkpoint(0)),
+        config,
+    );
+    futures::pin_mut!(stream);
+    assert_eq!(
+        stream
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .checkpoint
+            .unwrap()
+            .sequence_number,
+        Some(2)
+    );
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::PermissionDenied);
+    assert_eq!(
+        permission_server.state.lock().unwrap().calls,
+        [
+            "get_service_info",
+            "list_checkpoints",
+            "subscribe_checkpoints"
+        ]
+    );
+    let mut events = Vec::new();
+    while let Ok(event) = permission_events.try_recv() {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 4);
+    assert!(matches!(
+        &events[0],
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Checkpoint,
+            operation: LedgerStreamOperation::GetServiceInfo,
+            stage: LedgerStreamStage::InitialReplay,
+            code: tonic::Code::Ok,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[1],
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Checkpoint,
+            operation: LedgerStreamOperation::List,
+            stage: LedgerStreamStage::InitialReplay,
+            code: tonic::Code::Ok,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[2],
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Checkpoint,
+            operation: LedgerStreamOperation::Subscribe,
+            stage: LedgerStreamStage::LiveSubscription,
+            code: tonic::Code::PermissionDenied,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[3],
+        LedgerStreamEvent::TerminalError {
+            family: LedgerStreamFamily::Checkpoint,
+            status,
+            ..
+        } if status.code() == tonic::Code::PermissionDenied
+            && status.message() == "subscription denied"
+    ));
+}
+
+#[tokio::test]
+async fn service_info_retry_and_validation() {
+    let (retry_server, _calls) = ScriptedStreamServer::new();
+    retry_server.push_service_infos([
+        Err(tonic::Status::unavailable("service-info first")),
+        Err(tonic::Status::aborted("service-info second")),
+        Ok(service_info(2)),
+    ]);
+    retry_server.push_checkpoint_lists([
+        StreamScript::DispatchError(tonic::Status::unavailable("List first")),
+        StreamScript::DispatchError(tonic::Status::aborted("List second")),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(2), 2, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(retry_server.clone()).await;
+    let (client, observations) = observed_client(address);
+    let stream = client.stream_checkpoints_with_config(
+        CheckpointStreamRequest::new()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_start(CheckpointStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    let frame = stream.next().await.unwrap().unwrap();
+    assert_eq!(frame.checkpoint.unwrap().sequence_number, Some(2));
+    {
+        let state = retry_server.state.lock().unwrap();
+        assert_eq!(state.service_info_requests.len(), 3);
+        assert_eq!(state.checkpoint_requests.len(), 3);
+    }
+    let get_service_info_observations = observations
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|observation| observation.path.contains("GetServiceInfo"))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(get_service_info_observations.len(), 3);
+
+    let (missing_server, _calls) = ScriptedStreamServer::new();
+    missing_server.push_service_infos([Ok(proto::GetServiceInfoResponse::default())]);
+    let address = spawn_server(missing_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new()
+            .with_read_mask(event_identity_mask())
+            .with_start(EventStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "GetServiceInfo response is missing checkpoint_height"
+    );
+    assert_eq!(
+        missing_server.state.lock().unwrap().calls,
+        ["get_service_info"]
+    );
+
+    let (overflow_server, _calls) = ScriptedStreamServer::new();
+    overflow_server.push_service_infos([Ok(service_info(u64::MAX))]);
+    let address = spawn_server(overflow_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new()
+            .with_read_mask(event_identity_mask())
+            .with_start(EventStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::OutOfRange);
+    assert_eq!(
+        status.message(),
+        "checkpoint height cannot be converted to an exclusive end bound"
+    );
+    assert_eq!(
+        overflow_server.state.lock().unwrap().calls,
+        ["get_service_info"]
+    );
+
+    async fn assert_zero_interval<T: std::fmt::Debug>(
+        stream: impl futures::Stream<Item = Result<T, tonic::Status>>,
+    ) {
+        futures::pin_mut!(stream);
+        let status = stream.next().await.unwrap().unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(
+            status.message(),
+            "ledger_tip_poll_interval must be greater than zero"
+        );
+    }
+
+    let (invalid_config_server, _calls) = ScriptedStreamServer::new();
+    let address = spawn_server(invalid_config_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = fast_config();
+    config.ledger_tip_poll_interval = Duration::ZERO;
+    assert_zero_interval(
+        client.stream_transactions_with_config(
+            TransactionStreamRequest::new()
+                .with_read_mask(transaction_identity_mask())
+                .with_start(TransactionStreamStart::Checkpoint(0)),
+            config.clone(),
+        ),
+    )
+    .await;
+    assert_zero_interval(client.stream_checkpoints_with_config(
+        CheckpointStreamRequest::new().with_read_mask(checkpoint_identity_mask()),
+        config,
+    ))
+    .await;
+    assert!(invalid_config_server.state.lock().unwrap().calls.is_empty());
+}
+
+#[tokio::test]
+async fn dropping_during_tip_poll_sleep_prevents_later_rpc() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(2)), Ok(service_info(3))]);
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(2), 2, None)),
+            Ok(event_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let collector = tokio::spawn(async move {
+        let stream = client.stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_delivery(Delivery::Poll),
+            {
+                let mut config = fast_config();
+                config.ledger_tip_poll_interval = Duration::from_millis(50);
+                config
+            },
+        );
+        futures::pin_mut!(stream);
+        assert!(stream.next().await.unwrap().is_ok());
+        stream.next().await
+    });
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    tokio::task::yield_now().await;
+    collector.abort();
+    assert!(collector.await.unwrap_err().is_cancelled());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.service_info_requests.len(), 2);
+    assert_eq!(state.event_requests.len(), 2);
+    assert!(state.event_subscriptions.is_empty());
+}
+
+#[tokio::test]
+async fn ledger_tip_polling_redispatches_until_the_fixed_bound() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(9))]);
+    let (bound_tx, bound_rx) = mpsc::unbounded_channel();
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            4,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+        StreamScript::Channel(bound_rx),
+    ]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new()
+                    .with_read_mask(event_identity_mask())
+                    .with_start(EventStreamStart::Checkpoint(0)),
+                fast_config(),
+            )
+            .take(2)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert!(!collector.is_finished());
+    bound_tx
+        .send(Ok(event_positioned_list_frame(
+            None,
+            10,
+            9,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )))
+        .unwrap();
+    let frames = collector.await.unwrap().unwrap();
+    assert!(frames.iter().all(|frame| frame.event.is_none()));
+    assert_eq!(
+        frames
+            .into_iter()
+            .map(|frame| frame.cursor)
+            .collect::<Vec<_>>(),
+        [bytes(4), bytes(10)]
+    );
+}
+
+#[tokio::test]
+async fn dispatch_internal_stays_terminal() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_subscriptions([
+        StreamScript::DispatchError(tonic::Status::internal("dispatch failed")),
+        StreamScript::frames([Ok(event_live_frame(None, 30))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new().with_read_mask(event_identity_mask()),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+
+    let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for terminal dispatch failure")
+        .unwrap()
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::Internal);
+    assert_eq!(status.message(), "dispatch failed");
+    assert!(stream.next().await.is_none());
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.calls, ["subscribe_events"]);
+    assert!(state.service_info_requests.is_empty());
+    assert!(state.event_requests.is_empty());
+}
+
+#[tokio::test]
+async fn persisted_positions_resume_with_poll_delivery() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(2)), Ok(service_info(4))]);
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(2), 2, None)),
+            Ok(event_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(3), 3, None)),
+            Ok(event_list_frame(Some(4), 4, None)),
+            Ok(event_list_frame(
+                None,
+                4,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, observations) = observed_client(address);
+
+    let first_frames = client
+        .stream_events(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_start(EventStreamStart::Checkpoint(2))
+                .with_delivery(Delivery::Poll),
+        )
+        .take(1)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(first_frames.len(), 1);
+    assert_eq!(first_frames[0].event.as_ref().unwrap().checkpoint, Some(2));
+    assert_eq!(first_frames[0].cursor, bytes(2));
+
+    let resume_request = EventStreamRequest::new()
+        .with_read_mask(event_identity_mask())
+        .with_start(EventStreamStart::Resume(first_frames[0].cursor.clone()))
+        .with_delivery(Delivery::Poll);
+    let resumed = client
+        .stream_events(resume_request)
+        .take(2)
+        .try_filter_map(|frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) })
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(resumed, [3, 4]);
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.calls,
+        [
+            "get_service_info",
+            "list_events",
+            "get_service_info",
+            "list_events"
+        ]
+    );
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(2))
+    );
+    assert!(state.event_subscriptions.is_empty());
+    drop(state);
+    assert!(
+        observations
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|observation| !observation.path.contains("Subscribe"))
+    );
+}

--- a/crates/sui-rpc/tests/ledger_streams/reconnect.rs
+++ b/crates/sui-rpc/tests/ledger_streams/reconnect.rs
@@ -1,0 +1,251 @@
+use super::support::ScriptedStreamServer;
+use super::support::StreamScript;
+use super::support::bounded_event_request;
+use super::support::bytes;
+use super::support::event_list_frame;
+use super::support::event_positioned_list_frame;
+use super::support::fast_list_config;
+use super::support::first_list_event_error;
+use super::support::next_scripted_call;
+use super::support::observed_client;
+use super::support::spawn_server;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use std::time::Duration;
+use sui_rpc::client::ListConfig;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+#[tokio::test]
+async fn transient_retries_and_in_body_resume_preserve_the_safe_watermark() {
+    let (unlimited_server, _calls) = ScriptedStreamServer::new();
+    unlimited_server.push_event_lists(
+        (0..6)
+            .map(|attempt| {
+                StreamScript::DispatchError(tonic::Status::unavailable(format!(
+                    "unlimited-{attempt}"
+                )))
+            })
+            .chain([StreamScript::frames([
+                Ok(event_list_frame(Some(9), 9, None)),
+                Ok(event_positioned_list_frame(
+                    None,
+                    10,
+                    9,
+                    Some(proto::QueryEndReason::CheckpointBound),
+                )),
+            ])]),
+    );
+    let address = spawn_server(unlimited_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let events = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .list_events_with_config(bounded_event_request(), fast_list_config())
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.event_type.unwrap()))
+            })
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for repeated transient List retries")
+    .unwrap();
+    assert_eq!(events, ["event-9"]);
+    assert_eq!(
+        unlimited_server.state.lock().unwrap().event_requests.len(),
+        7
+    );
+
+    let (resume_server, _calls) = ScriptedStreamServer::new();
+    resume_server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(2), 2, None)),
+            Ok(event_list_frame(None, 4, None)),
+            Err(tonic::Status::unavailable("body failed")),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Ok(event_positioned_list_frame(
+                None,
+                10,
+                9,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(resume_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let events = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .list_events_with_config(bounded_event_request(), fast_list_config())
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.event_type.unwrap()))
+            })
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for in-body List resume")
+    .unwrap();
+    assert_eq!(events, ["event-2", "event-5"]);
+    let state = resume_server.state.lock().unwrap();
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(4))
+    );
+}
+
+#[tokio::test]
+async fn transient_retry_backoff_is_exponential_and_capped() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_event_lists(
+        (0..4)
+            .map(|attempt| {
+                StreamScript::DispatchError(tonic::Status::unavailable(format!(
+                    "attempt-{attempt}"
+                )))
+            })
+            .chain([StreamScript::frames([
+                Ok(event_list_frame(Some(9), 9, None)),
+                Ok(event_positioned_list_frame(
+                    None,
+                    10,
+                    9,
+                    Some(proto::QueryEndReason::CheckpointBound),
+                )),
+            ])]),
+    );
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = ListConfig::default();
+    config.base_retry_delay = Duration::from_millis(50);
+    config.max_retry_delay = Duration::from_millis(150);
+    config.retry_jitter = Duration::ZERO;
+    let collector = tokio::spawn(async move {
+        client
+            .list_events_with_config(bounded_event_request(), config)
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.event_type.unwrap()))
+            })
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    for expected_delay in [50, 100, 150].map(Duration::from_millis) {
+        let started = std::time::Instant::now();
+        assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= expected_delay,
+            "retry dispatched after {elapsed:?}, before {expected_delay:?}"
+        );
+    }
+    let capped_retry_started = std::time::Instant::now();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_millis(300), next_scripted_call(&mut calls),)
+            .await
+            .expect("retry exceeded twice the configured backoff cap"),
+        "list_events"
+    );
+    let capped_retry_elapsed = capped_retry_started.elapsed();
+    assert!(
+        capped_retry_elapsed >= Duration::from_millis(150),
+        "capped retry dispatched after {capped_retry_elapsed:?}, before its configured delay"
+    );
+
+    let events = tokio::time::timeout(Duration::from_secs(2), collector)
+        .await
+        .expect("timed out waiting for capped transient retries")
+        .unwrap()
+        .unwrap();
+    assert_eq!(events, ["event-9"]);
+}
+
+#[tokio::test]
+async fn non_retryable_status_is_forwarded_without_reconnect() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([StreamScript::DispatchError(
+        tonic::Status::invalid_argument("bad filter"),
+    )]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let status = first_list_event_error(&client, bounded_event_request(), fast_list_config()).await;
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert_eq!(status.message(), "bad filter");
+    assert_eq!(server.state.lock().unwrap().event_requests.len(), 1);
+}
+
+#[tokio::test]
+async fn dropping_facade_during_retry_sleep_prevents_later_rpc() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_event_lists([
+        StreamScript::DispatchError(tonic::Status::unavailable("sleep")),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = ListConfig::default();
+    config.base_retry_delay = Duration::from_millis(50);
+    config.max_retry_delay = Duration::from_millis(50);
+    config.retry_jitter = Duration::ZERO;
+    let collector = tokio::spawn(async move {
+        let stream = client.list_events_with_config(bounded_event_request(), config);
+        futures::pin_mut!(stream);
+        stream.next().await
+    });
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    collector.abort();
+    let _ = collector.await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(server.state.lock().unwrap().event_requests.len(), 1);
+}
+
+#[tokio::test]
+async fn list_body_unknown_interruption_retries() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_lists([
+        StreamScript::frames([
+            Ok(event_list_frame(Some(5), 5, None)),
+            Err(tonic::Status::unknown(
+                "error reading a body from connection",
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(6), 6, None)),
+            Ok(event_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let event_ids = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .list_events_with_config(
+                bounded_event_request().with_end_checkpoint(8),
+                fast_list_config(),
+            )
+            .try_filter_map(
+                |frame| async move { Ok(frame.event.and_then(|event| event.checkpoint)) },
+            )
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for an Internal List body retry")
+    .unwrap();
+
+    assert_eq!(event_ids, [5, 6]);
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.calls, ["list_events", "list_events"]);
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(5))
+    );
+}

--- a/crates/sui-rpc/tests/ledger_streams/reconnect.rs
+++ b/crates/sui-rpc/tests/ledger_streams/reconnect.rs
@@ -1,19 +1,1148 @@
+use super::support::STREAM_DROP_TIMEOUT;
 use super::support::ScriptedStreamServer;
 use super::support::StreamScript;
 use super::support::bounded_event_request;
 use super::support::bytes;
+use super::support::checkpoint_identity_mask;
+use super::support::checkpoint_list_frame;
+use super::support::checkpoint_live_frame;
+use super::support::event;
+use super::support::event_at;
+use super::support::event_identity_mask;
 use super::support::event_list_frame;
+use super::support::event_live_frame;
 use super::support::event_positioned_list_frame;
+use super::support::event_positioned_live_frame;
+use super::support::fast_config;
 use super::support::fast_list_config;
+use super::support::first_event_error;
 use super::support::first_list_event_error;
 use super::support::next_scripted_call;
 use super::support::observed_client;
+use super::support::recording_config;
+use super::support::service_info;
 use super::support::spawn_server;
+use super::support::transaction_at;
+use super::support::transaction_identity_mask;
+use super::support::transaction_list_frame;
+use super::support::transaction_live_frame;
+use super::support::transaction_positioned_list_frame;
+use super::support::transaction_positioned_live_frame;
 use futures::StreamExt;
 use futures::TryStreamExt;
+use std::num::NonZeroUsize;
 use std::time::Duration;
+use sui_rpc::client::CheckpointStreamRequest;
+use sui_rpc::client::CheckpointStreamStart;
+use sui_rpc::client::EventStreamRequest;
+use sui_rpc::client::EventStreamStart;
+use sui_rpc::client::LedgerStreamConfig;
+use sui_rpc::client::LedgerStreamEvent;
+use sui_rpc::client::LedgerStreamFamily;
+use sui_rpc::client::LedgerStreamOperation;
+use sui_rpc::client::LedgerStreamStage;
 use sui_rpc::client::ListConfig;
+use sui_rpc::client::TransactionStreamRequest;
+use sui_rpc::client::TransactionStreamStart;
 use sui_rpc::proto::sui::rpc::v2 as proto;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn lagging_new_subscriptions_catch_up_without_reconnect_churn_for_all_families() {
+    let (checkpoint_server, _calls) = ScriptedStreamServer::new();
+    checkpoint_server.push_service_infos([Ok(service_info(10))]);
+    checkpoint_server.push_checkpoint_subscriptions([StreamScript::frames([
+        Ok(checkpoint_live_frame(None, 8)),
+        Ok(checkpoint_live_frame(None, 9)),
+        Ok(checkpoint_live_frame(None, 10)),
+        Ok(checkpoint_live_frame(Some(11), 11)),
+    ])]);
+    checkpoint_server.push_checkpoint_lists([StreamScript::frames([Ok(checkpoint_list_frame(
+        None,
+        10,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(checkpoint_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let checkpoint_frames = client
+        .stream_checkpoints_with_config(
+            CheckpointStreamRequest::new()
+                .with_read_mask(checkpoint_identity_mask())
+                .with_filter(proto::TransactionFilter::default())
+                .with_start(CheckpointStreamStart::Checkpoint(0)),
+            fast_config(),
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(checkpoint_frames[0].checkpoint.is_none());
+    assert_eq!(checkpoint_frames[0].cursor, 10);
+    assert_eq!(
+        checkpoint_frames[1]
+            .checkpoint
+            .as_ref()
+            .unwrap()
+            .sequence_number,
+        Some(11)
+    );
+    {
+        let state = checkpoint_server.state.lock().unwrap();
+        assert_eq!(state.checkpoint_subscriptions.len(), 1);
+        assert_eq!(state.checkpoint_requests.len(), 1);
+    }
+
+    let (transaction_server, _calls) = ScriptedStreamServer::new();
+    transaction_server.push_service_infos([Ok(service_info(10))]);
+    transaction_server.push_transaction_subscriptions([StreamScript::frames([
+        Ok(transaction_live_frame(None, 8)),
+        Ok(transaction_live_frame(None, 9)),
+        Ok(transaction_live_frame(None, 10)),
+        Ok(transaction_live_frame(Some(11), 11)),
+    ])]);
+    transaction_server.push_transaction_lists([StreamScript::frames([Ok(
+        transaction_list_frame(None, 10, Some(proto::QueryEndReason::CheckpointBound)),
+    )])]);
+    let address = spawn_server(transaction_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let transaction_frames = client
+        .stream_transactions_with_config(
+            TransactionStreamRequest::new()
+                .with_read_mask(transaction_identity_mask())
+                .with_start(TransactionStreamStart::Checkpoint(0)),
+            fast_config(),
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(transaction_frames[0].transaction.is_none());
+    assert_eq!(transaction_frames[0].cursor, bytes(10));
+    assert_eq!(
+        transaction_frames[1]
+            .transaction
+            .as_ref()
+            .unwrap()
+            .digest
+            .as_deref(),
+        Some("tx-11")
+    );
+    {
+        let state = transaction_server.state.lock().unwrap();
+        assert_eq!(state.transaction_subscriptions.len(), 1);
+        assert_eq!(state.transaction_requests.len(), 1);
+    }
+
+    let (event_server, _calls) = ScriptedStreamServer::new();
+    event_server.push_service_infos([Ok(service_info(10))]);
+    event_server.push_event_subscriptions([StreamScript::frames([
+        Ok(event_live_frame(None, 8)),
+        Ok(event_live_frame(None, 9)),
+        Ok(event_live_frame(None, 10)),
+        Ok(event_live_frame(Some(11), 11)),
+    ])]);
+    event_server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        10,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(event_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let event_frames = client
+        .stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_start(EventStreamStart::Checkpoint(0)),
+            fast_config(),
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(event_frames[0].event.is_none());
+    assert_eq!(event_frames[0].cursor, bytes(10));
+    assert_eq!(
+        event_frames[1]
+            .event
+            .as_ref()
+            .unwrap()
+            .event_type
+            .as_deref(),
+        Some("event-11")
+    );
+    let state = event_server.state.lock().unwrap();
+    assert_eq!(state.event_subscriptions.len(), 1);
+    assert_eq!(state.event_requests.len(), 1);
+}
+
+#[tokio::test]
+async fn lagging_opaque_subscription_replays_unknown_cursor_order_before_live_data() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10))]);
+    let mut unknown_cursor_order_progress = event_live_frame(None, 9);
+    unknown_cursor_order_progress
+        .watermark
+        .as_mut()
+        .unwrap()
+        .checkpoint = Some(10);
+    server.push_event_subscriptions([StreamScript::frames([
+        Ok(event_live_frame(None, 8)),
+        Ok(unknown_cursor_order_progress),
+        Ok(event_live_frame(Some(12), 12)),
+    ])]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([Ok(event_positioned_list_frame(
+            None,
+            9,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let frames = client
+        .stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_start(EventStreamStart::Checkpoint(0)),
+            fast_config(),
+        )
+        .take(3)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+
+    assert!(frames[0].event.is_none());
+    assert_eq!(frames[0].cursor, bytes(10));
+    assert_eq!(frames[0].covered_checkpoint, Some(10));
+    assert!(frames[1].event.is_none());
+    assert_eq!(frames[1].cursor, bytes(9));
+    assert_eq!(frames[1].covered_checkpoint, Some(10));
+    assert_eq!(
+        frames[2].event.as_ref().unwrap().event_type.as_deref(),
+        Some("event-12")
+    );
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_subscriptions.len(), 1);
+    assert_eq!(state.event_requests.len(), 2);
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(10))
+    );
+    assert_eq!(
+        state.event_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        None,
+    );
+    assert_eq!(state.event_requests[1].body.end_checkpoint, Some(11));
+}
+
+#[tokio::test]
+async fn same_checkpoint_transaction_reconnect_replays_immediately_and_deduplicates_positions() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10))]);
+    let (subscription_tx, subscription_rx) = mpsc::unbounded_channel();
+    let (recovery_tx, recovery_rx) = mpsc::unbounded_channel();
+    server.push_transaction_subscriptions([StreamScript::Channel(subscription_rx)]);
+    server.push_transaction_lists([
+        StreamScript::frames([Ok(transaction_positioned_list_frame(
+            None,
+            100,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::Channel(recovery_rx),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let body = TransactionStreamRequest::new()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec![
+                "digest".to_owned(),
+                "checkpoint".to_owned(),
+                "transaction_index".to_owned(),
+            ],
+        })
+        .with_start(TransactionStreamStart::Resume(bytes(50)));
+    let collector = tokio::spawn(async move {
+        let mut config = fast_config();
+        config.list_page_limit = Some(7);
+        client
+            .stream_transactions_with_config(body, config)
+            .take(5)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_transactions");
+    assert_eq!(
+        next_scripted_call(&mut calls).await,
+        "subscribe_transactions"
+    );
+    subscription_tx
+        .send(Ok(transaction_positioned_live_frame(
+            Some(transaction_at(10, 1, "retained-and-listed")),
+            900,
+            10,
+        )))
+        .unwrap();
+    assert_eq!(
+        next_scripted_call(&mut calls).await,
+        "list_transactions",
+        "same-checkpoint recovery must not wait for another subscription frame"
+    );
+    subscription_tx
+        .send(Ok(transaction_positioned_live_frame(
+            Some(transaction_at(10, 2, "retained-only")),
+            901,
+            10,
+        )))
+        .unwrap();
+    recovery_tx
+        .send(Ok(transaction_positioned_list_frame(
+            Some(transaction_at(10, 0, "list-only")),
+            800,
+            10,
+            None,
+        )))
+        .unwrap();
+    recovery_tx
+        .send(Ok(transaction_positioned_list_frame(
+            Some(transaction_at(10, 1, "retained-and-listed")),
+            900,
+            10,
+            None,
+        )))
+        .unwrap();
+    recovery_tx
+        .send(Ok(transaction_positioned_list_frame(
+            None,
+            900,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )))
+        .unwrap();
+    subscription_tx
+        .send(Ok(transaction_positioned_live_frame(
+            Some(transaction_at(11, 0, "live-after-drain")),
+            1_000,
+            11,
+        )))
+        .unwrap();
+
+    let frames = tokio::time::timeout(Duration::from_secs(2), collector)
+        .await
+        .expect("same-checkpoint transaction recovery stalled")
+        .unwrap()
+        .unwrap();
+    let transactions = frames
+        .iter()
+        .filter_map(|frame| frame.transaction.as_ref())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        transactions
+            .iter()
+            .map(|transaction| transaction.digest.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        [
+            "list-only",
+            "retained-and-listed",
+            "retained-only",
+            "live-after-drain",
+        ]
+    );
+    assert!(
+        transactions
+            .iter()
+            .all(|transaction| transaction.checkpoint.is_some()
+                && transaction.transaction_index.is_some())
+    );
+    assert_eq!(frames.last().unwrap().cursor, bytes(1_000));
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.transaction_subscriptions.len(), 1);
+    assert_eq!(state.transaction_requests.len(), 2);
+    assert_eq!(
+        state.transaction_requests[0]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .after,
+        Some(bytes(50))
+    );
+    assert_eq!(
+        state.transaction_requests[0]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .limit,
+        Some(7)
+    );
+    let recovery_request = &state.transaction_requests[1].body;
+    assert_eq!(recovery_request.end_checkpoint, Some(11));
+    assert_eq!(
+        recovery_request.options.as_ref().unwrap().after,
+        Some(bytes(100))
+    );
+    assert_eq!(recovery_request.options.as_ref().unwrap().before, None);
+    assert_eq!(recovery_request.options.as_ref().unwrap().limit, Some(7));
+    assert!(
+        recovery_request
+            .options
+            .as_ref()
+            .unwrap()
+            .ordering
+            .is_none()
+    );
+    assert_eq!(
+        recovery_request.read_mask.as_ref().unwrap().paths,
+        ["digest", "checkpoint", "transaction_index"]
+    );
+    assert_eq!(
+        state.transaction_subscriptions[0]
+            .body
+            .read_mask
+            .as_ref()
+            .unwrap()
+            .paths,
+        ["digest", "checkpoint", "transaction_index"]
+    );
+}
+
+#[tokio::test]
+async fn same_checkpoint_progress_only_reconnect_replays_immediately() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10))]);
+    let (subscription_tx, subscription_rx) = mpsc::unbounded_channel();
+    let (recovery_tx, recovery_rx) = mpsc::unbounded_channel();
+    server.push_transaction_subscriptions([StreamScript::Channel(subscription_rx)]);
+    server.push_transaction_lists([
+        StreamScript::frames([Ok(transaction_positioned_list_frame(
+            None,
+            100,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::Channel(recovery_rx),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let collector = tokio::spawn(async move {
+        client
+            .stream_transactions_with_config(
+                TransactionStreamRequest::new()
+                    .with_read_mask(transaction_identity_mask())
+                    .with_start(TransactionStreamStart::Checkpoint(0)),
+                fast_config(),
+            )
+            .take(4)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_transactions");
+    assert_eq!(
+        next_scripted_call(&mut calls).await,
+        "subscribe_transactions"
+    );
+    subscription_tx
+        .send(Ok(transaction_positioned_live_frame(None, 900, 10)))
+        .unwrap();
+    assert_eq!(
+        next_scripted_call(&mut calls).await,
+        "list_transactions",
+        "same-checkpoint recovery must not wait for an item-bearing subscription frame"
+    );
+
+    recovery_tx
+        .send(Ok(transaction_positioned_list_frame(
+            Some(transaction_at(10, 0, "replayed")),
+            800,
+            10,
+            None,
+        )))
+        .unwrap();
+    recovery_tx
+        .send(Ok(transaction_positioned_list_frame(
+            None,
+            900,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )))
+        .unwrap();
+    subscription_tx
+        .send(Ok(transaction_positioned_live_frame(
+            Some(transaction_at(11, 0, "live")),
+            1_000,
+            11,
+        )))
+        .unwrap();
+
+    let frames = tokio::time::timeout(Duration::from_secs(2), collector)
+        .await
+        .expect("progress-only same-checkpoint recovery stalled")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        frames
+            .iter()
+            .filter_map(|frame| frame.transaction.as_ref())
+            .map(|transaction| transaction.digest.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        ["replayed", "live"]
+    );
+    assert_eq!(frames.last().unwrap().cursor, bytes(1_000));
+}
+
+#[tokio::test]
+async fn same_checkpoint_event_reconnect_replays_immediately_and_deduplicates_positions() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10))]);
+    let (subscription_tx, subscription_rx) = mpsc::unbounded_channel();
+    let (recovery_tx, recovery_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([StreamScript::Channel(subscription_rx)]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_positioned_list_frame(
+            None,
+            100,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::Channel(recovery_rx),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let body = EventStreamRequest::new()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec![
+                "event_type".to_owned(),
+                "checkpoint".to_owned(),
+                "transaction_index".to_owned(),
+                "event_index".to_owned(),
+            ],
+        })
+        .with_start(EventStreamStart::Checkpoint(0));
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(body, fast_config())
+            .take(5)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+    subscription_tx
+        .send(Ok(event_positioned_live_frame(
+            Some(event_at(10, 1, 0, "retained-and-listed")),
+            900,
+            10,
+        )))
+        .unwrap();
+    assert_eq!(
+        next_scripted_call(&mut calls).await,
+        "list_events",
+        "same-checkpoint recovery must not wait for another subscription frame"
+    );
+    subscription_tx
+        .send(Ok(event_positioned_live_frame(
+            Some(event_at(10, 1, 1, "retained-only")),
+            901,
+            10,
+        )))
+        .unwrap();
+    recovery_tx
+        .send(Ok(event_positioned_list_frame(
+            Some(event_at(10, 0, 0, "list-only")),
+            800,
+            10,
+            None,
+        )))
+        .unwrap();
+    recovery_tx
+        .send(Ok(event_positioned_list_frame(
+            Some(event_at(10, 1, 0, "retained-and-listed")),
+            900,
+            10,
+            None,
+        )))
+        .unwrap();
+    recovery_tx
+        .send(Ok(event_positioned_list_frame(
+            None,
+            900,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )))
+        .unwrap();
+    subscription_tx
+        .send(Ok(event_positioned_live_frame(
+            Some(event_at(11, 0, 0, "live-after-drain")),
+            1_000,
+            11,
+        )))
+        .unwrap();
+
+    let frames = tokio::time::timeout(Duration::from_secs(2), collector)
+        .await
+        .expect("same-checkpoint event recovery stalled")
+        .unwrap()
+        .unwrap();
+    let events = frames
+        .iter()
+        .filter_map(|frame| frame.event.as_ref())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| event.event_type.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        [
+            "list-only",
+            "retained-and-listed",
+            "retained-only",
+            "live-after-drain",
+        ]
+    );
+    assert!(events.iter().all(|event| {
+        event.checkpoint.is_some()
+            && event.transaction_index.is_some()
+            && event.event_index.is_some()
+    }));
+    assert_eq!(frames.last().unwrap().cursor, bytes(1_000));
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_subscriptions.len(), 1);
+    assert_eq!(state.event_requests.len(), 2);
+    let recovery_request = &state.event_requests[1].body;
+    assert_eq!(recovery_request.end_checkpoint, Some(11));
+    assert_eq!(
+        recovery_request.options.as_ref().unwrap().after,
+        Some(bytes(100))
+    );
+    assert_eq!(recovery_request.options.as_ref().unwrap().before, None);
+    assert_eq!(
+        recovery_request.read_mask.as_ref().unwrap().paths,
+        [
+            "event_type",
+            "checkpoint",
+            "transaction_index",
+            "event_index"
+        ]
+    );
+    assert_eq!(
+        state.event_subscriptions[0]
+            .body
+            .read_mask
+            .as_ref()
+            .unwrap()
+            .paths,
+        [
+            "event_type",
+            "checkpoint",
+            "transaction_index",
+            "event_index"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn filtered_opaque_bootstrap_and_subscription_gap_release_boundary_once() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(5)), Ok(service_info(5))]);
+    server.push_transaction_subscriptions([StreamScript::frames([Ok(transaction_live_frame(
+        Some(7),
+        7,
+    ))])]);
+    server.push_transaction_lists([
+        StreamScript::frames([Ok(transaction_list_frame(
+            None,
+            5,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(6), 6, None)),
+            Ok(transaction_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    server.push_event_subscriptions([StreamScript::frames([Ok(event_live_frame(Some(7), 7))])]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            5,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(6), 6, None)),
+            Ok(event_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let transaction_request = TransactionStreamRequest::new()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec![
+                "digest".to_owned(),
+                "checkpoint".to_owned(),
+                "transaction_index".to_owned(),
+            ],
+        })
+        .with_filter(proto::TransactionFilter::default())
+        .with_start(TransactionStreamStart::Checkpoint(0));
+    let transactions = client
+        .stream_transactions_with_config(transaction_request, fast_config())
+        .try_filter_map(|frame| async move {
+            Ok(frame
+                .transaction
+                .map(|transaction| transaction.digest.unwrap()))
+        })
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(transactions, ["tx-6", "tx-7"]);
+
+    let event_request = EventStreamRequest::new()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec![
+                "event_type".to_owned(),
+                "checkpoint".to_owned(),
+                "transaction_index".to_owned(),
+                "event_index".to_owned(),
+            ],
+        })
+        .with_filter(proto::EventFilter::default())
+        .with_start(EventStreamStart::Checkpoint(0));
+    let events = client
+        .stream_events_with_config(event_request, fast_config())
+        .try_filter_map(
+            |frame| async move { Ok(frame.event.map(|event| event.event_type.unwrap())) },
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(events, ["event-6", "event-7"]);
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.transaction_requests[0].body.end_checkpoint, Some(6));
+    assert_eq!(
+        state.transaction_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .after,
+        Some(bytes(5))
+    );
+    assert_eq!(
+        state.transaction_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(7))
+    );
+    assert_eq!(state.event_requests[0].body.end_checkpoint, Some(6));
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(5))
+    );
+    assert_eq!(
+        state.event_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(7))
+    );
+    assert_eq!(state.transaction_subscriptions.len(), 1);
+    assert_eq!(state.event_subscriptions.len(), 1);
+}
+
+#[tokio::test]
+async fn dropped_event_stream_replays_index_lag_before_buffered_live_data() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10)), Ok(service_info(12))]);
+    server.push_event_subscriptions([
+        StreamScript::frames([
+            Ok(event_live_frame(None, 10)),
+            Ok(event_live_frame(Some(11), 11)),
+            Ok(event_live_frame(None, 12)),
+            Err(tonic::Status::unavailable("dropped live stream")),
+        ]),
+        StreamScript::frames([
+            Ok(event_live_frame(None, 16)),
+            Ok(event_live_frame(Some(17), 17)),
+        ]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            12,
+            Some(proto::QueryEndReason::LedgerTip),
+        ))]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(14), 14, None)),
+            Ok(event_list_frame(Some(15), 15, None)),
+            Ok(event_list_frame(
+                None,
+                16,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let events = client
+        .stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_start(EventStreamStart::Checkpoint(0)),
+            fast_config(),
+        )
+        .try_filter_map(
+            |frame| async move { Ok(frame.event.map(|event| event.event_type.unwrap())) },
+        )
+        .take(4)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(events, ["event-11", "event-14", "event-15", "event-17"]);
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.event_requests[1].body.options.as_ref().unwrap().after,
+        Some(bytes(12))
+    );
+    assert_eq!(
+        state.event_requests[1]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(16))
+    );
+    assert_eq!(
+        state.event_requests[2].body.options.as_ref().unwrap().after,
+        Some(bytes(12))
+    );
+    assert_eq!(
+        state.event_requests[2]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(16))
+    );
+}
+
+#[tokio::test]
+async fn replay_defers_and_coalesces_progress_until_the_fixed_gap_completes() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(0))]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    let (gap_tx, gap_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([
+        StreamScript::Channel(live_rx),
+        StreamScript::frames([Ok(event_live_frame(Some(7), 7))]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::Channel(gap_rx),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(6), 6, None)),
+            Ok(event_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = fast_config();
+    config.max_buffered_live_items = NonZeroUsize::new(2).unwrap();
+    let (config, mut observer_events) = recording_config(config);
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new()
+                    .with_read_mask(event_identity_mask())
+                    .with_start(EventStreamStart::Checkpoint(0)),
+                config,
+            )
+            .take(7)
+            .map_ok(|frame| {
+                (
+                    frame.event.map(|event| event.event_type.unwrap()),
+                    frame.cursor,
+                )
+            })
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(calls.recv().await, Some("get_service_info"));
+    assert_eq!(calls.recv().await, Some("list_events"));
+    assert_eq!(calls.recv().await, Some("subscribe_events"));
+    live_tx.send(Ok(event_live_frame(Some(2), 2))).unwrap();
+    assert_eq!(calls.recv().await, Some("list_events"));
+    live_tx.send(Ok(event_live_frame(None, 3))).unwrap();
+    live_tx.send(Ok(event_live_frame(None, 4))).unwrap();
+    live_tx.send(Ok(event_live_frame(Some(5), 5))).unwrap();
+    tokio::time::timeout(STREAM_DROP_TIMEOUT, live_tx.closed())
+        .await
+        .expect("item cap did not drop the pinned subscription");
+    let mut semantic_events = Vec::new();
+    while let Ok(event) = observer_events.try_recv() {
+        if !matches!(&event, LedgerStreamEvent::RpcResponse { .. }) {
+            semantic_events.push(event);
+        }
+    }
+    assert_eq!(semantic_events.len(), 2);
+    assert!(matches!(
+        &semantic_events[0],
+        LedgerStreamEvent::GapRecoveryStarted {
+            family: LedgerStreamFamily::Event,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &semantic_events[1],
+        LedgerStreamEvent::SubscriptionBufferLimitReached {
+            family: LedgerStreamFamily::Event,
+            buffered_items: 2,
+            limit: 2,
+            ..
+        }
+    ));
+    gap_tx.send(Ok(event_list_frame(Some(1), 1, None))).unwrap();
+    gap_tx
+        .send(Ok(event_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CursorBound),
+        )))
+        .unwrap();
+
+    let events = collector.await.unwrap().unwrap();
+    assert_eq!(
+        events,
+        [
+            (None, bytes(0)),
+            (Some("event-1".to_owned()), bytes(1)),
+            (Some("event-2".to_owned()), bytes(2)),
+            (None, bytes(4)),
+            (Some("event-5".to_owned()), bytes(5)),
+            (Some("event-6".to_owned()), bytes(6)),
+            (Some("event-7".to_owned()), bytes(7)),
+        ]
+    );
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.event_requests[2].body.options.as_ref().unwrap().after,
+        Some(bytes(5))
+    );
+    assert_eq!(
+        state.event_requests[2]
+            .body
+            .options
+            .as_ref()
+            .unwrap()
+            .before,
+        Some(bytes(7))
+    );
+    drop(state);
+}
+
+#[tokio::test]
+async fn live_failure_during_replay_is_deferred_until_valid_buffer_is_delivered() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(0)), Ok(service_info(2))]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    let (gap_tx, gap_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([
+        StreamScript::Channel(live_rx),
+        StreamScript::frames([Ok(event_live_frame(Some(5), 5))]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::Channel(gap_rx),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(4), 4, None)),
+            Ok(event_list_frame(
+                None,
+                5,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut observer_events) = recording_config(fast_config());
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new()
+                    .with_read_mask(event_identity_mask())
+                    .with_start(EventStreamStart::Checkpoint(0)),
+                config,
+            )
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.event_type.unwrap()))
+            })
+            .take(5)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(calls.recv().await, Some("get_service_info"));
+    assert_eq!(calls.recv().await, Some("list_events"));
+    assert_eq!(calls.recv().await, Some("subscribe_events"));
+    live_tx.send(Ok(event_live_frame(Some(2), 2))).unwrap();
+    assert_eq!(calls.recv().await, Some("list_events"));
+
+    match observer_events.recv().await.unwrap() {
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Event,
+            operation: LedgerStreamOperation::GetServiceInfo,
+            stage: LedgerStreamStage::InitialReplay,
+            code: tonic::Code::Ok,
+            ..
+        } => {}
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+    match observer_events.recv().await.unwrap() {
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Event,
+            operation: LedgerStreamOperation::List,
+            stage: LedgerStreamStage::InitialReplay,
+            code: tonic::Code::Ok,
+            ..
+        } => {}
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+    match observer_events.recv().await.unwrap() {
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Event,
+            operation: LedgerStreamOperation::Subscribe,
+            stage: LedgerStreamStage::LiveSubscription,
+            code: tonic::Code::Ok,
+            ..
+        } => {}
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+    match observer_events.recv().await.unwrap() {
+        LedgerStreamEvent::GapRecoveryStarted {
+            family: LedgerStreamFamily::Event,
+            ..
+        } => {}
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+    match observer_events.recv().await.unwrap() {
+        LedgerStreamEvent::RpcResponse {
+            family: LedgerStreamFamily::Event,
+            operation: LedgerStreamOperation::List,
+            stage: LedgerStreamStage::GapRecovery,
+            code: tonic::Code::Ok,
+            ..
+        } => {}
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+    assert!(observer_events.try_recv().is_err());
+
+    live_tx.send(Ok(event_live_frame(Some(3), 3))).unwrap();
+    live_tx
+        .send(Err(tonic::Status::unavailable("pinned stream failed")))
+        .unwrap();
+    match observer_events.recv().await.unwrap() {
+        LedgerStreamEvent::SubscriptionStreamInterrupted {
+            family: LedgerStreamFamily::Event,
+            stage: LedgerStreamStage::GapRecovery,
+            status,
+            ..
+        } => {
+            assert_eq!(status.code(), tonic::Code::Unavailable);
+            assert_eq!(status.message(), "pinned stream failed");
+        }
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+    assert!(observer_events.try_recv().is_err());
+    tokio::time::timeout(STREAM_DROP_TIMEOUT, live_tx.closed())
+        .await
+        .expect("failed pinned stream was not dropped");
+    gap_tx.send(Ok(event_list_frame(Some(1), 1, None))).unwrap();
+    gap_tx
+        .send(Ok(event_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CursorBound),
+        )))
+        .unwrap();
+
+    assert_eq!(
+        collector.await.unwrap().unwrap(),
+        ["event-1", "event-2", "event-3", "event-4", "event-5"]
+    );
+    match observer_events.recv().await.unwrap() {
+        LedgerStreamEvent::RetryScheduled {
+            family: LedgerStreamFamily::Event,
+            operation: LedgerStreamOperation::Subscribe,
+            stage: LedgerStreamStage::GapRecovery,
+            status,
+            consecutive_failures: 1,
+            delay: Duration::ZERO,
+            ..
+        } => {
+            assert_eq!(status.code(), tonic::Code::Unavailable);
+            assert_eq!(status.message(), "pinned stream failed");
+        }
+        event => panic!("unexpected observer event: {event:?}"),
+    }
+}
+
 #[tokio::test]
 async fn transient_retries_and_in_body_resume_preserve_the_safe_watermark() {
     let (unlimited_server, _calls) = ScriptedStreamServer::new();
@@ -161,6 +1290,143 @@ async fn transient_retry_backoff_is_exponential_and_capped() {
 }
 
 #[tokio::test]
+async fn list_and_subscription_failures_use_independent_retry_states() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10)), Ok(service_info(11))]);
+    let (second_subscription_tx, second_subscription_rx) = mpsc::unbounded_channel();
+    let (third_tx, third_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([
+        StreamScript::Channel(second_subscription_rx),
+        StreamScript::Channel(third_rx),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(11), 11, None)),
+            Err(tonic::Status::unavailable("List failed after progress")),
+        ]),
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            11,
+            Some(proto::QueryEndReason::CursorBound),
+        ))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let mut config = LedgerStreamConfig::default();
+    config.base_retry_delay = Duration::from_millis(200);
+    config.max_retry_delay = Duration::from_millis(800);
+    config.retry_jitter = Duration::ZERO;
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new()
+                    .with_read_mask(event_identity_mask())
+                    .with_start(EventStreamStart::Checkpoint(0)),
+                config,
+            )
+            .take(4)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+    second_subscription_tx
+        .send(Ok(event_live_frame(None, 12)))
+        .unwrap();
+    second_subscription_tx
+        .send(Err(tonic::Status::unavailable(
+            "subscription failed during replay",
+        )))
+        .unwrap();
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    let list_retry_started = std::time::Instant::now();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_millis(350), next_scripted_call(&mut calls),)
+            .await
+            .expect("List retry exceeded its independent base delay window"),
+        "list_events"
+    );
+    let list_retry_elapsed = list_retry_started.elapsed();
+    assert!(
+        list_retry_elapsed >= Duration::from_millis(200),
+        "List retry dispatched after {list_retry_elapsed:?}, before its base delay"
+    );
+    let subscription_recovery_started = std::time::Instant::now();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_millis(350), next_scripted_call(&mut calls),)
+            .await
+            .expect("Subscribe recovery exceeded its independent base delay window"),
+        "get_service_info"
+    );
+    let subscription_recovery_elapsed = subscription_recovery_started.elapsed();
+    assert!(
+        subscription_recovery_elapsed >= Duration::from_millis(200),
+        "Subscribe recovery dispatched after {subscription_recovery_elapsed:?}, before its base delay"
+    );
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+
+    collector.abort();
+    assert!(collector.await.unwrap_err().is_cancelled());
+    tokio::time::timeout(STREAM_DROP_TIMEOUT, third_tx.closed())
+        .await
+        .expect("third subscription was not dropped");
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_requests.len(), 3);
+    assert_eq!(state.event_subscriptions.len(), 2);
+}
+
+#[tokio::test]
+async fn reconnection_requires_checkpoint_coverage_in_its_initial_frame() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(5)), Ok(service_info(5))]);
+    let mut invalid_reconnection_boundary = event_live_frame(None, 6);
+    invalid_reconnection_boundary
+        .watermark
+        .as_mut()
+        .unwrap()
+        .checkpoint = None;
+    server.push_event_subscriptions([
+        StreamScript::frames([Ok(event_live_frame(None, 5))]),
+        StreamScript::frames([Ok(invalid_reconnection_boundary)]),
+    ]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        5,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new()
+            .with_read_mask(event_identity_mask())
+            .with_start(EventStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+
+    let history = stream.next().await.unwrap().unwrap();
+    assert_eq!(history.cursor, bytes(5));
+    assert_eq!(history.covered_checkpoint, Some(5));
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "subscription initial frame is missing checkpoint coverage"
+    );
+    assert!(stream.next().await.is_none());
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_subscriptions.len(), 2);
+    assert_eq!(state.event_requests.len(), 1);
+}
+
+#[tokio::test]
 async fn non_retryable_status_is_forwarded_without_reconnect() {
     let (server, _calls) = ScriptedStreamServer::new();
     server.push_event_lists([StreamScript::DispatchError(
@@ -172,6 +1438,107 @@ async fn non_retryable_status_is_forwarded_without_reconnect() {
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
     assert_eq!(status.message(), "bad filter");
     assert_eq!(server.state.lock().unwrap().event_requests.len(), 1);
+}
+
+#[tokio::test]
+async fn checkpoint_gap_rejects_out_of_order_buffered_live_frames() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10))]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    let (gap_tx, gap_rx) = mpsc::unbounded_channel();
+    server.push_checkpoint_subscriptions([StreamScript::Channel(live_rx)]);
+    server.push_checkpoint_lists([
+        StreamScript::frames([Ok(checkpoint_list_frame(
+            None,
+            10,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::Channel(gap_rx),
+    ]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let collector = tokio::spawn(async move {
+        let stream = client.stream_checkpoints_with_config(
+            CheckpointStreamRequest::new()
+                .with_read_mask(checkpoint_identity_mask())
+                .with_filter(proto::TransactionFilter::default())
+                .with_start(CheckpointStreamStart::Checkpoint(0)),
+            fast_config(),
+        );
+        futures::pin_mut!(stream);
+        let progress = stream.next().await.unwrap().unwrap();
+        assert!(progress.checkpoint.is_none());
+        assert_eq!(progress.cursor, 10);
+        let gap_progress = stream.next().await.unwrap().unwrap();
+        assert!(gap_progress.checkpoint.is_none());
+        assert_eq!(gap_progress.cursor, 15);
+        stream.next().await.unwrap().unwrap_err()
+    });
+
+    assert_eq!(calls.recv().await, Some("get_service_info"));
+    assert_eq!(calls.recv().await, Some("list_checkpoints"));
+    assert_eq!(calls.recv().await, Some("subscribe_checkpoints"));
+    live_tx.send(Ok(checkpoint_live_frame(None, 15))).unwrap();
+    assert_eq!(calls.recv().await, Some("list_checkpoints"));
+    live_tx
+        .send(Ok(checkpoint_live_frame(Some(14), 14)))
+        .unwrap();
+    tokio::time::timeout(STREAM_DROP_TIMEOUT, live_tx.closed())
+        .await
+        .expect("regressing live stream was not dropped");
+    gap_tx
+        .send(Ok(checkpoint_list_frame(
+            None,
+            15,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )))
+        .unwrap();
+
+    let status = collector.await.unwrap();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+}
+
+#[tokio::test]
+async fn dropping_live_facade_drops_the_tonic_stream_without_reconnecting() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(0))]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([StreamScript::Channel(live_rx)]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        0,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let mut stream = Box::pin(
+        client.stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_start(EventStreamStart::Checkpoint(0)),
+            fast_config(),
+        ),
+    );
+    let orchestration = tokio::spawn(async move {
+        assert_eq!(calls.recv().await, Some("get_service_info"));
+        assert_eq!(calls.recv().await, Some("list_events"));
+        assert_eq!(calls.recv().await, Some("subscribe_events"));
+        live_tx.send(Ok(event_live_frame(None, 0))).unwrap();
+        live_tx.send(Ok(event_live_frame(Some(1), 1))).unwrap();
+        live_tx
+    });
+    let progress = stream.next().await.unwrap().unwrap();
+    assert!(progress.event.is_none());
+    assert_eq!(progress.cursor, bytes(0));
+    let item = stream.next().await.unwrap().unwrap();
+    assert_eq!(item.event.unwrap().event_type.as_deref(), Some("event-1"));
+    let live_tx = orchestration.await.unwrap();
+    drop(stream);
+    tokio::time::timeout(STREAM_DROP_TIMEOUT, live_tx.closed())
+        .await
+        .expect("dropping facade did not drop tonic response");
+    tokio::task::yield_now().await;
+    assert_eq!(server.state.lock().unwrap().calls.len(), 3);
 }
 
 #[tokio::test]
@@ -201,6 +1568,343 @@ async fn dropping_facade_during_retry_sleep_prevents_later_rpc() {
     let _ = collector.await;
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert_eq!(server.state.lock().unwrap().event_requests.len(), 1);
+}
+
+#[tokio::test]
+async fn clean_subscription_eof_uses_the_transient_recovery_policy() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(0)), Ok(service_info(0))]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        0,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    server.push_event_subscriptions([
+        StreamScript::frames([]),
+        StreamScript::DispatchError(tonic::Status::permission_denied(
+            "subscription retry denied",
+        )),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let config = fast_config();
+    let body = EventStreamRequest::new()
+        .with_read_mask(event_identity_mask())
+        .with_start(EventStreamStart::Resume(bytes(0)));
+    let status = first_event_error(&client, body, config).await;
+    assert_eq!(status.code(), tonic::Code::PermissionDenied);
+    assert_eq!(server.state.lock().unwrap().event_subscriptions.len(), 2);
+}
+
+#[tokio::test]
+async fn gap_recovery_without_list_coverage_still_plans_replay_on_reconnect() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    let (first_gap_tx, first_gap_rx) = mpsc::unbounded_channel();
+    let (second_subscription_tx, second_subscription_rx) = mpsc::unbounded_channel();
+    let (third_subscription_tx, third_subscription_rx) = mpsc::unbounded_channel();
+    server.push_service_infos([Ok(service_info(0)), Ok(service_info(0))]);
+    server.push_event_subscriptions([
+        StreamScript::frames([
+            Ok(event_live_frame(None, 0)),
+            Err(tonic::Status::unavailable("initial subscription failed")),
+        ]),
+        StreamScript::Channel(second_subscription_rx),
+        StreamScript::Channel(third_subscription_rx),
+    ]);
+    let mut first_gap_item = event_positioned_list_frame(Some(event(1)), 1, 0, None);
+    first_gap_item.watermark.as_mut().unwrap().checkpoint = None;
+    let mut first_gap_second_item = event_positioned_list_frame(Some(event(2)), 2, 0, None);
+    first_gap_second_item.watermark.as_mut().unwrap().checkpoint = None;
+    let mut first_gap_end =
+        event_positioned_list_frame(None, 3, 0, Some(proto::QueryEndReason::CursorBound));
+    first_gap_end.watermark.as_mut().unwrap().checkpoint = None;
+    let mut second_gap_item = event_positioned_list_frame(Some(event(4)), 4, 0, None);
+    second_gap_item.watermark.as_mut().unwrap().checkpoint = None;
+    let mut second_gap_end =
+        event_positioned_list_frame(None, 5, 0, Some(proto::QueryEndReason::CursorBound));
+    second_gap_end.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_event_lists([
+        StreamScript::Channel(first_gap_rx),
+        StreamScript::frames([Ok(second_gap_item), Ok(second_gap_end)]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let collector = tokio::spawn(async move {
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new().with_read_mask(event_identity_mask()),
+                fast_config(),
+            )
+            .try_filter_map(|frame| async move {
+                Ok(frame.event.map(|event| event.event_type.unwrap()))
+            })
+            .take(3)
+            .try_collect::<Vec<_>>()
+            .await
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+    second_subscription_tx
+        .send(Ok(event_live_frame(Some(2), 3)))
+        .unwrap();
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    first_gap_tx.send(Ok(first_gap_item)).unwrap();
+    second_subscription_tx
+        .send(Err(tonic::Status::unavailable(
+            "subscription failed during gap replay",
+        )))
+        .unwrap();
+    tokio::time::timeout(STREAM_DROP_TIMEOUT, second_subscription_tx.closed())
+        .await
+        .expect("failed gap subscription was not dropped");
+    first_gap_tx.send(Ok(first_gap_second_item)).unwrap();
+    first_gap_tx.send(Ok(first_gap_end)).unwrap();
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+    third_subscription_tx
+        .send(Ok(event_live_frame(Some(5), 5)))
+        .unwrap();
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), collector)
+            .await
+            .expect("stream stalled instead of replaying the next cursor gap")
+            .unwrap()
+            .unwrap(),
+        ["event-1", "event-2", "event-4"]
+    );
+}
+
+#[tokio::test]
+async fn server_internal_mid_stream_is_terminal() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_subscriptions([
+        StreamScript::frames([
+            Ok(event_live_frame(None, 10)),
+            Ok(event_live_frame(Some(11), 11)),
+            Err(tonic::Status::internal("server bug")),
+        ]),
+        StreamScript::frames([Ok(event_live_frame(None, 11))]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new().with_read_mask(event_identity_mask()),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+
+    assert!(stream.next().await.unwrap().is_ok());
+    assert!(stream.next().await.unwrap().is_ok());
+    let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for terminal Internal")
+        .unwrap()
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::Internal);
+    assert_eq!(status.message(), "server bug");
+    assert!(stream.next().await.is_none());
+    assert_eq!(server.state.lock().unwrap().calls, ["subscribe_events"]);
+}
+
+#[tokio::test]
+async fn live_stream_cancelled_and_unknown_interruptions_reconnect() {
+    for interruption in [
+        tonic::Status::cancelled("server cancelled response body"),
+        tonic::Status::unknown("h2 response body failure"),
+    ] {
+        let (server, _calls) = ScriptedStreamServer::new();
+        server.push_service_infos([Ok(service_info(21))]);
+        server.push_event_subscriptions([
+            StreamScript::frames([
+                Ok(event_live_frame(None, 20)),
+                Ok(event_live_frame(Some(21), 21)),
+                Err(interruption),
+            ]),
+            StreamScript::frames([
+                Ok(event_live_frame(None, 21)),
+                Ok(event_live_frame(Some(22), 22)),
+            ]),
+        ]);
+        let address = spawn_server(server.clone()).await;
+        let (client, _observations) = observed_client(address);
+
+        let events = tokio::time::timeout(
+            Duration::from_secs(2),
+            client
+                .stream_events_with_config(
+                    EventStreamRequest::new().with_read_mask(event_identity_mask()),
+                    fast_config(),
+                )
+                .try_filter_map(|frame| async move {
+                    Ok(frame.event.map(|event| event.event_type.unwrap()))
+                })
+                .take(2)
+                .try_collect::<Vec<_>>(),
+        )
+        .await
+        .expect("timed out waiting for a body interruption retry")
+        .unwrap();
+
+        assert_eq!(events, ["event-21", "event-22"]);
+        assert_eq!(
+            server.state.lock().unwrap().calls,
+            ["subscribe_events", "get_service_info", "subscribe_events"]
+        );
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_tip_start_uses_list_while_initial_subscriptions_fail_before_first_frame() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let (_stalled_subscription_tx, stalled_subscription_rx) = mpsc::unbounded_channel();
+    server.push_checkpoint_subscriptions([
+        StreamScript::frames([Err(tonic::Status::deadline_exceeded("idle watchdog"))]),
+        StreamScript::frames([Err(tonic::Status::deadline_exceeded("idle watchdog"))]),
+        StreamScript::Channel(stalled_subscription_rx),
+    ]);
+    server.push_service_infos([Ok(service_info(0)), Ok(service_info(2))]);
+    server.push_checkpoint_lists([
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(0), 0, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                0,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(1), 1, None)),
+            Ok(checkpoint_list_frame(Some(2), 2, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut stream_events) = recording_config(fast_config());
+
+    let checkpoints = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_checkpoints_with_config(
+                CheckpointStreamRequest::new().with_read_mask(checkpoint_identity_mask()),
+                config,
+            )
+            .try_filter_map(|frame| async move {
+                Ok(frame
+                    .checkpoint
+                    .and_then(|checkpoint| checkpoint.sequence_number))
+            })
+            .take(2)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("pre-frame subscription failures starved live-tip List recovery")
+    .unwrap();
+
+    assert_eq!(checkpoints, [1, 2]);
+    let events: Vec<_> = std::iter::from_fn(|| stream_events.try_recv().ok()).collect();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                LedgerStreamEvent::SubscriptionStreamInterrupted { status, .. }
+                    if status.code() == tonic::Code::DeadlineExceeded
+            ))
+            .count(),
+        2,
+        "unexpected subscription interruption history: {events:#?}"
+    );
+    assert_eq!(
+        server.state.lock().unwrap().calls,
+        [
+            "subscribe_checkpoints",
+            "get_service_info",
+            "list_checkpoints",
+            "subscribe_checkpoints",
+            "get_service_info",
+            "list_checkpoints",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_reconnect_uses_list_when_replacement_fails_before_first_frame() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let (_stalled_subscription_tx, stalled_subscription_rx) = mpsc::unbounded_channel();
+    server.push_checkpoint_subscriptions([
+        StreamScript::frames([
+            Ok(checkpoint_live_frame(Some(0), 0)),
+            Err(tonic::Status::deadline_exceeded("idle watchdog")),
+        ]),
+        StreamScript::frames([Err(tonic::Status::deadline_exceeded("idle watchdog"))]),
+        StreamScript::Channel(stalled_subscription_rx),
+    ]);
+    server.push_service_infos([Ok(service_info(0)), Ok(service_info(2))]);
+    server.push_checkpoint_lists([StreamScript::frames([
+        Ok(checkpoint_list_frame(Some(1), 1, None)),
+        Ok(checkpoint_list_frame(Some(2), 2, None)),
+        Ok(checkpoint_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CheckpointBound),
+        )),
+    ])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut stream_events) = recording_config(fast_config());
+
+    let checkpoints = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_checkpoints_with_config(
+                CheckpointStreamRequest::new().with_read_mask(checkpoint_identity_mask()),
+                config,
+            )
+            .try_filter_map(|frame| async move {
+                Ok(frame
+                    .checkpoint
+                    .and_then(|checkpoint| checkpoint.sequence_number))
+            })
+            .take(3)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("repeated pre-frame subscription failures starved List recovery")
+    .unwrap();
+
+    assert_eq!(checkpoints, [0, 1, 2]);
+    let events: Vec<_> = std::iter::from_fn(|| stream_events.try_recv().ok()).collect();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            LedgerStreamEvent::GapRecoveryStarted {
+                family: LedgerStreamFamily::Checkpoint,
+                ..
+            }
+        )),
+        "checkpoint List recovery did not start: {events:#?}"
+    );
+    assert_eq!(
+        server.state.lock().unwrap().calls,
+        [
+            "subscribe_checkpoints",
+            "get_service_info",
+            "subscribe_checkpoints",
+            "get_service_info",
+            "list_checkpoints",
+        ]
+    );
 }
 
 #[tokio::test]
@@ -247,5 +1951,258 @@ async fn list_body_unknown_interruption_retries() {
     assert_eq!(
         state.event_requests[1].body.options.as_ref().unwrap().after,
         Some(bytes(5))
+    );
+}
+
+#[tokio::test]
+async fn live_item_with_repeated_cursor_is_terminal_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_subscriptions([StreamScript::frames([
+        Ok(event_live_frame(Some(1), 1)),
+        Ok(event_live_frame(Some(2), 1)),
+    ])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new().with_read_mask(event_identity_mask()),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    let item = stream.next().await.unwrap().unwrap();
+    assert_eq!(
+        item.event.as_ref().unwrap().event_type.as_deref(),
+        Some("event-1")
+    );
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(status.message(), "subscription item repeated its cursor");
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn muted_subscription_item_with_repeated_cursor_is_terminal_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10))]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        10,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    server.push_event_subscriptions([StreamScript::frames([
+        Ok(event_live_frame(None, 8)),
+        Ok(event_live_frame(Some(9), 8)),
+    ])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new()
+            .with_read_mask(event_identity_mask())
+            .with_start(EventStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    let history = stream.next().await.unwrap().unwrap();
+    assert!(history.event.is_none());
+    assert_eq!(history.cursor, bytes(10));
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(status.message(), "subscription item repeated its cursor");
+    assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn gap_buffered_item_with_repeated_cursor_is_terminal_data_loss() {
+    let (server, mut calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(0))]);
+    let (live_tx, live_rx) = mpsc::unbounded_channel();
+    let (gap_tx, gap_rx) = mpsc::unbounded_channel();
+    server.push_event_subscriptions([StreamScript::Channel(live_rx)]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::Channel(gap_rx),
+    ]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let collector = tokio::spawn(async move {
+        let stream = client.stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_start(EventStreamStart::Checkpoint(0)),
+            fast_config(),
+        );
+        futures::pin_mut!(stream);
+        let mut frames = Vec::new();
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(frame) => frames.push((
+                    frame.event.map(|event| event.event_type.unwrap()),
+                    frame.cursor,
+                )),
+                Err(status) => {
+                    let ended = stream.next().await.is_none();
+                    return (frames, status, ended);
+                }
+            }
+        }
+        panic!("stream ended without reporting repeated subscription cursor");
+    });
+
+    assert_eq!(next_scripted_call(&mut calls).await, "get_service_info");
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    assert_eq!(next_scripted_call(&mut calls).await, "subscribe_events");
+    live_tx.send(Ok(event_live_frame(Some(2), 2))).unwrap();
+    assert_eq!(next_scripted_call(&mut calls).await, "list_events");
+    live_tx.send(Ok(event_live_frame(Some(3), 2))).unwrap();
+    tokio::time::timeout(STREAM_DROP_TIMEOUT, live_tx.closed())
+        .await
+        .expect("malformed pinned subscription was not dropped");
+    gap_tx.send(Ok(event_list_frame(Some(1), 1, None))).unwrap();
+    gap_tx
+        .send(Ok(event_list_frame(
+            None,
+            2,
+            Some(proto::QueryEndReason::CursorBound),
+        )))
+        .unwrap();
+
+    let (frames, status, ended) = collector.await.unwrap();
+    assert_eq!(
+        frames,
+        [
+            (None, bytes(0)),
+            (Some("event-1".to_owned()), bytes(1)),
+            (Some("event-2".to_owned()), bytes(2)),
+        ]
+    );
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(status.message(), "subscription item repeated its cursor");
+    assert!(ended);
+}
+
+#[tokio::test]
+async fn equal_cursor_coverage_growth_updates_recovery_planning() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(21))]);
+    server.push_event_subscriptions([
+        StreamScript::frames([
+            Ok(event_positioned_live_frame(
+                Some(event_at(20, 0, 0, "event-20")),
+                10,
+                20,
+            )),
+            Ok(event_positioned_live_frame(None, 10, 21)),
+            Err(tonic::Status::unavailable("live stream interrupted")),
+        ]),
+        StreamScript::frames([
+            Ok(event_positioned_live_frame(None, 10, 21)),
+            Ok(event_positioned_live_frame(
+                Some(event_at(21, 0, 0, "event-21")),
+                11,
+                21,
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut observer_events) = recording_config(fast_config());
+
+    let frames = client
+        .stream_events_with_config(
+            EventStreamRequest::new().with_read_mask(event_identity_mask()),
+            config,
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(frames[0].cursor, bytes(10));
+    assert_eq!(frames[0].covered_checkpoint, Some(20));
+    assert_eq!(frames[1].cursor, bytes(11));
+    assert_eq!(frames[1].covered_checkpoint, Some(21));
+    while let Ok(event) = observer_events.try_recv() {
+        assert!(!matches!(
+            event,
+            LedgerStreamEvent::GapRecoveryStarted { .. }
+        ));
+    }
+    assert!(server.state.lock().unwrap().event_requests.is_empty());
+}
+
+#[tokio::test]
+async fn same_cursor_reconnect_preserves_committed_checkpoint_coverage() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(10)), Ok(service_info(10))]);
+    server.push_event_subscriptions([
+        StreamScript::frames([
+            Ok(event_positioned_live_frame(
+                Some(event_at(8, 0, 0, "already-delivered")),
+                100,
+                10,
+            )),
+            Err(tonic::Status::unavailable("first interruption")),
+        ]),
+        StreamScript::frames([
+            Ok(event_positioned_live_frame(None, 100, 5)),
+            Ok(event_positioned_live_frame(None, 100, 6)),
+            Err(tonic::Status::unavailable("second interruption")),
+        ]),
+        StreamScript::frames([
+            Ok(event_positioned_live_frame(None, 200, 8)),
+            Ok(event_positioned_live_frame(
+                Some(event_at(8, 0, 0, "already-delivered")),
+                201,
+                9,
+            )),
+            Ok(event_positioned_live_frame(None, 100, 10)),
+            Ok(event_positioned_live_frame(
+                Some(event_at(11, 0, 0, "after-committed-frontier")),
+                300,
+                11,
+            )),
+        ]),
+    ]);
+    server.push_event_lists([StreamScript::frames([Ok(event_positioned_list_frame(
+        None,
+        100,
+        6,
+        Some(proto::QueryEndReason::CursorBound),
+    ))])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+
+    let frames = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new().with_read_mask(event_identity_mask()),
+                fast_config(),
+            )
+            .take(2)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("muted subscription did not reach the committed frontier")
+    .unwrap();
+
+    assert_eq!(
+        frames
+            .iter()
+            .map(|frame| frame.cursor.clone())
+            .collect::<Vec<_>>(),
+        [bytes(100), bytes(300)]
+    );
+    assert_eq!(
+        frames
+            .iter()
+            .filter_map(|frame| frame.event.as_ref())
+            .map(|event| event.event_type.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        ["already-delivered", "after-committed-frontier"]
     );
 }

--- a/crates/sui-rpc/tests/ledger_streams/startup.rs
+++ b/crates/sui-rpc/tests/ledger_streams/startup.rs
@@ -1,0 +1,951 @@
+use super::support::ScriptedStreamServer;
+use super::support::StreamScript;
+use super::support::bytes;
+use super::support::checkpoint_identity_mask;
+use super::support::checkpoint_list_frame;
+use super::support::checkpoint_live_frame;
+use super::support::event_identity_mask;
+use super::support::event_list_frame;
+use super::support::event_live_frame;
+use super::support::fast_config;
+use super::support::observed_client;
+use super::support::recording_config;
+use super::support::service_info;
+use super::support::spawn_server;
+use super::support::transaction_identity_mask;
+use super::support::transaction_list_frame;
+use super::support::transaction_live_frame;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use std::time::Duration;
+use sui_rpc::client::CheckpointStreamRequest;
+use sui_rpc::client::CheckpointStreamStart;
+use sui_rpc::client::EventStreamRequest;
+use sui_rpc::client::EventStreamStart;
+use sui_rpc::client::LedgerStreamConfig;
+use sui_rpc::client::LedgerStreamEvent;
+use sui_rpc::client::TransactionStreamRequest;
+use sui_rpc::client::TransactionStreamStart;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+
+#[tokio::test]
+async fn steady_live_streams_yield_advanced_progress_only_frames() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([
+        Ok(service_info(0)),
+        Ok(service_info(0)),
+        Ok(service_info(0)),
+    ]);
+    server.push_checkpoint_subscriptions([StreamScript::frames([
+        Ok(checkpoint_live_frame(None, 0)),
+        Ok(checkpoint_live_frame(None, 2)),
+    ])]);
+    server.push_checkpoint_lists([StreamScript::frames([Ok(checkpoint_list_frame(
+        None,
+        0,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    server.push_transaction_subscriptions([StreamScript::frames([
+        Ok(transaction_live_frame(None, 0)),
+        Ok(transaction_live_frame(None, 2)),
+    ])]);
+    server.push_transaction_lists([StreamScript::frames([Ok(transaction_list_frame(
+        None,
+        0,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    server.push_event_subscriptions([StreamScript::frames([
+        Ok(event_live_frame(None, 0)),
+        Ok(event_live_frame(None, 2)),
+    ])]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        0,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server).await;
+    let (client, _observations) = observed_client(address);
+    let (config, mut observer_events) = recording_config(LedgerStreamConfig::default());
+
+    let checkpoint_frames = client
+        .stream_checkpoints_with_config(
+            CheckpointStreamRequest::new()
+                .with_read_mask(checkpoint_identity_mask())
+                .with_filter(proto::TransactionFilter::default())
+                .with_start(CheckpointStreamStart::Checkpoint(0)),
+            config.clone(),
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(
+        checkpoint_frames
+            .iter()
+            .all(|frame| frame.checkpoint.is_none())
+    );
+    assert_eq!(
+        checkpoint_frames
+            .iter()
+            .map(|frame| frame.cursor)
+            .collect::<Vec<_>>(),
+        [0, 2]
+    );
+
+    let transaction_frames = client
+        .stream_transactions_with_config(
+            TransactionStreamRequest::new()
+                .with_read_mask(transaction_identity_mask())
+                .with_start(TransactionStreamStart::Checkpoint(0)),
+            config.clone(),
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(
+        transaction_frames
+            .iter()
+            .all(|frame| frame.transaction.is_none())
+    );
+    assert_eq!(
+        transaction_frames
+            .iter()
+            .map(|frame| frame.cursor.clone())
+            .collect::<Vec<_>>(),
+        [bytes(0), bytes(2)]
+    );
+
+    let event_frames = client
+        .stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(event_identity_mask())
+                .with_start(EventStreamStart::Checkpoint(0)),
+            config,
+        )
+        .take(2)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(event_frames.iter().all(|frame| frame.event.is_none()));
+    assert_eq!(
+        event_frames
+            .iter()
+            .map(|frame| frame.cursor.clone())
+            .collect::<Vec<_>>(),
+        [bytes(0), bytes(2)]
+    );
+
+    let mut events = Vec::new();
+    while let Ok(event) = observer_events.try_recv() {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 9);
+    assert!(
+        events
+            .iter()
+            .all(|event| matches!(event, LedgerStreamEvent::RpcResponse { .. }))
+    );
+}
+
+#[tokio::test]
+async fn live_tip_uses_subscribe_delivery_for_all_families() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_checkpoint_subscriptions([StreamScript::frames([Ok(checkpoint_live_frame(
+        Some(11),
+        11,
+    ))])]);
+    server.push_transaction_subscriptions([StreamScript::frames([
+        Ok(transaction_live_frame(None, 11)),
+        Ok(transaction_live_frame(Some(12), 12)),
+    ])]);
+    server.push_event_subscriptions([StreamScript::frames([
+        Ok(event_live_frame(None, 12)),
+        Ok(event_live_frame(Some(13), 13)),
+    ])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let checkpoint_stream = client.stream_checkpoints(
+        CheckpointStreamRequest::new().with_read_mask(checkpoint_identity_mask()),
+    );
+    futures::pin_mut!(checkpoint_stream);
+    let checkpoint_frame = tokio::time::timeout(Duration::from_secs(2), checkpoint_stream.next())
+        .await
+        .expect("timed out waiting for live-tip checkpoint")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        checkpoint_frame.checkpoint.unwrap().sequence_number,
+        Some(11)
+    );
+
+    let transaction_frames = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_transactions(
+                TransactionStreamRequest::new().with_read_mask(transaction_identity_mask()),
+            )
+            .take(2)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for live-tip transactions")
+    .unwrap();
+    assert!(transaction_frames[0].transaction.is_none());
+    assert_eq!(transaction_frames[0].covered_checkpoint, Some(11));
+    assert_eq!(
+        transaction_frames[1]
+            .transaction
+            .as_ref()
+            .unwrap()
+            .digest
+            .as_deref(),
+        Some("tx-12")
+    );
+
+    let event_frames = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_events(EventStreamRequest::new().with_read_mask(event_identity_mask()))
+            .take(2)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for live-tip events")
+    .unwrap();
+    assert!(event_frames[0].event.is_none());
+    assert_eq!(event_frames[0].covered_checkpoint, Some(12));
+    assert_eq!(
+        event_frames[1]
+            .event
+            .as_ref()
+            .unwrap()
+            .event_type
+            .as_deref(),
+        Some("event-13")
+    );
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.calls,
+        [
+            "subscribe_checkpoints",
+            "subscribe_transactions",
+            "subscribe_events"
+        ]
+    );
+    assert!(state.service_info_requests.is_empty());
+    assert!(state.checkpoint_requests.is_empty());
+    assert!(state.transaction_requests.is_empty());
+    assert!(state.event_requests.is_empty());
+}
+
+#[tokio::test]
+async fn subscription_initial_frame_without_checkpoint_coverage_is_data_loss() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    let mut transaction_boundary = transaction_live_frame(None, 20);
+    transaction_boundary.watermark.as_mut().unwrap().checkpoint = None;
+    let mut event_boundary = event_live_frame(None, 30);
+    event_boundary.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_transaction_subscriptions([StreamScript::frames([Ok(transaction_boundary)])]);
+    server.push_event_subscriptions([StreamScript::frames([Ok(event_boundary)])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let transactions = client.stream_transactions(
+        TransactionStreamRequest::new().with_read_mask(transaction_identity_mask()),
+    );
+    futures::pin_mut!(transactions);
+    let transaction_status = tokio::time::timeout(Duration::from_secs(2), transactions.next())
+        .await
+        .expect("timed out waiting for invalid transaction boundary")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(transaction_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        transaction_status.message(),
+        "subscription initial frame is missing checkpoint coverage"
+    );
+    assert!(transactions.next().await.is_none());
+
+    let events =
+        client.stream_events(EventStreamRequest::new().with_read_mask(event_identity_mask()));
+    futures::pin_mut!(events);
+    let event_status = tokio::time::timeout(Duration::from_secs(2), events.next())
+        .await
+        .expect("timed out waiting for invalid event boundary")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(event_status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        event_status.message(),
+        "subscription initial frame is missing checkpoint coverage"
+    );
+    assert!(events.next().await.is_none());
+    assert_eq!(
+        server.state.lock().unwrap().calls,
+        ["subscribe_transactions", "subscribe_events"]
+    );
+}
+
+#[tokio::test]
+async fn startup_transient_failure_uses_list_baseline_before_reconnecting() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(40))]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        40,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    server.push_event_subscriptions([
+        StreamScript::frames([Err(tonic::Status::unavailable(
+            "initial subscription failed before its first frame",
+        ))]),
+        StreamScript::frames([
+            Ok(event_live_frame(None, 40)),
+            Ok(event_live_frame(Some(41), 41)),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let frames = tokio::time::timeout(
+        Duration::from_secs(2),
+        client
+            .stream_events_with_config(
+                EventStreamRequest::new().with_read_mask(event_identity_mask()),
+                fast_config(),
+            )
+            .take(1)
+            .try_collect::<Vec<_>>(),
+    )
+    .await
+    .expect("timed out waiting for startup retry")
+    .unwrap();
+    assert_eq!(frames.len(), 1);
+    assert_eq!(
+        frames[0].event.as_ref().unwrap().event_type.as_deref(),
+        Some("event-41")
+    );
+    assert_eq!(frames[0].cursor, bytes(41));
+    assert_eq!(
+        server.state.lock().unwrap().calls,
+        [
+            "subscribe_events",
+            "get_service_info",
+            "list_events",
+            "subscribe_events",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn startup_nontransient_failure_is_terminal() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_event_subscriptions([StreamScript::frames([Err(
+        tonic::Status::invalid_argument("invalid startup request"),
+    )])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new().with_read_mask(event_identity_mask()),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+
+    let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for terminal startup failure")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert_eq!(status.message(), "invalid startup request");
+    assert!(stream.next().await.is_none());
+    assert_eq!(server.state.lock().unwrap().calls, ["subscribe_events"]);
+}
+
+#[tokio::test]
+async fn stream_read_masks_require_identity_but_lists_allow_any_projection() {
+    async fn assert_invalid<T: std::fmt::Debug>(
+        stream: impl futures::Stream<Item = Result<T, tonic::Status>>,
+        expected_message: &str,
+    ) {
+        futures::pin_mut!(stream);
+        let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("timed out waiting for lazy read-mask validation")
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), expected_message);
+    }
+
+    fn field_mask(paths: &[&str]) -> prost_types::FieldMask {
+        prost_types::FieldMask {
+            paths: paths.iter().map(|path| (*path).to_owned()).collect(),
+        }
+    }
+
+    let (server, _calls) = ScriptedStreamServer::new();
+    let mut projected_checkpoint = checkpoint_list_frame(Some(1), 1, None);
+    projected_checkpoint
+        .checkpoint
+        .as_mut()
+        .unwrap()
+        .sequence_number = None;
+    server.push_checkpoint_lists([StreamScript::frames([
+        Ok(projected_checkpoint),
+        Ok(checkpoint_list_frame(
+            None,
+            1,
+            Some(proto::QueryEndReason::LedgerTip),
+        )),
+    ])]);
+    let mut projected_transaction = transaction_list_frame(Some(1), 1, None);
+    let projected_transaction_item = projected_transaction.transaction.as_mut().unwrap();
+    projected_transaction_item.checkpoint = None;
+    projected_transaction_item.transaction_index = None;
+    server.push_transaction_lists([StreamScript::frames([
+        Ok(projected_transaction),
+        Ok(transaction_list_frame(
+            None,
+            1,
+            Some(proto::QueryEndReason::LedgerTip),
+        )),
+    ])]);
+    let mut projected_event = event_list_frame(Some(1), 1, None);
+    let projected_event_item = projected_event.event.as_mut().unwrap();
+    projected_event_item.checkpoint = None;
+    projected_event_item.transaction_index = None;
+    projected_event_item.event_index = None;
+    server.push_event_lists([StreamScript::frames([
+        Ok(projected_event),
+        Ok(event_list_frame(
+            None,
+            1,
+            Some(proto::QueryEndReason::LedgerTip),
+        )),
+    ])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, observations) = observed_client(address);
+
+    let checkpoint_message = r#"read_mask must include "sequence_number" or "*""#;
+    for read_mask in [
+        None,
+        Some(prost_types::FieldMask::default()),
+        Some(field_mask(&["digest"])),
+    ] {
+        let mut stream_request = CheckpointStreamRequest::new();
+        stream_request.read_mask = read_mask;
+        assert_invalid(
+            client.stream_checkpoints(stream_request),
+            checkpoint_message,
+        )
+        .await;
+        assert!(server.state.lock().unwrap().calls.is_empty());
+    }
+
+    let transaction_message =
+        r#"read_mask must include "checkpoint" and "transaction_index" or "*""#;
+    for read_mask in [
+        None,
+        Some(prost_types::FieldMask::default()),
+        Some(field_mask(&["checkpoint"])),
+        Some(field_mask(&["transaction_index"])),
+    ] {
+        let mut stream_request = TransactionStreamRequest::new();
+        stream_request.read_mask = read_mask;
+        assert_invalid(
+            client.stream_transactions(stream_request),
+            transaction_message,
+        )
+        .await;
+        assert!(server.state.lock().unwrap().calls.is_empty());
+    }
+
+    let event_message =
+        r#"read_mask must include "checkpoint", "transaction_index", and "event_index" or "*""#;
+    for read_mask in [
+        None,
+        Some(prost_types::FieldMask::default()),
+        Some(field_mask(&["transaction_index", "event_index"])),
+        Some(field_mask(&["checkpoint", "event_index"])),
+        Some(field_mask(&["checkpoint", "transaction_index"])),
+    ] {
+        let mut stream_request = EventStreamRequest::new();
+        stream_request.read_mask = read_mask;
+        assert_invalid(client.stream_events(stream_request), event_message).await;
+        assert!(server.state.lock().unwrap().calls.is_empty());
+    }
+    assert!(observations.lock().unwrap().is_empty());
+
+    let checkpoint = client.list_checkpoints(
+        proto::ListCheckpointsRequest::default().with_read_mask(field_mask(&["digest"])),
+    );
+    futures::pin_mut!(checkpoint);
+    assert!(
+        checkpoint
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .checkpoint
+            .is_some()
+    );
+    assert!(
+        checkpoint
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .checkpoint
+            .is_none()
+    );
+    assert!(checkpoint.next().await.is_none());
+
+    let transaction = client.list_transactions(
+        proto::ListTransactionsRequest::default().with_read_mask(field_mask(&["digest"])),
+    );
+    futures::pin_mut!(transaction);
+    assert!(
+        transaction
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .transaction
+            .is_some()
+    );
+    assert!(
+        transaction
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .transaction
+            .is_none()
+    );
+    assert!(transaction.next().await.is_none());
+
+    let event = client.list_events(
+        proto::ListEventsRequest::default().with_read_mask(field_mask(&["event_type"])),
+    );
+    futures::pin_mut!(event);
+    assert!(event.next().await.unwrap().unwrap().event.is_some());
+    assert!(event.next().await.unwrap().unwrap().event.is_none());
+    assert!(event.next().await.is_none());
+    assert_eq!(
+        server.state.lock().unwrap().calls,
+        ["list_checkpoints", "list_transactions", "list_events"]
+    );
+}
+
+#[tokio::test]
+async fn service_info_bootstrap_and_subscription_handoff_have_no_gap_or_duplicate() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(5))]);
+    server.push_checkpoint_subscriptions([StreamScript::frames([
+        Ok(checkpoint_live_frame(Some(7), 7)),
+        Ok(checkpoint_live_frame(Some(8), 8)),
+    ])]);
+    server.push_checkpoint_lists([
+        StreamScript::frames(
+            (0..=5)
+                .map(|value| Ok(checkpoint_list_frame(Some(value), value, None)))
+                .chain([Ok(checkpoint_list_frame(
+                    None,
+                    5,
+                    Some(proto::QueryEndReason::CheckpointBound),
+                ))]),
+        ),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(6), 6, None)),
+            Ok(checkpoint_list_frame(Some(7), 7, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    let address = spawn_server(server.clone()).await;
+    let (client, observations) = observed_client(address);
+
+    let body = CheckpointStreamRequest::new()
+        .with_read_mask(prost_types::FieldMask {
+            paths: vec!["sequence_number".to_owned()],
+        })
+        .with_filter(proto::TransactionFilter::default())
+        .with_start(CheckpointStreamStart::Checkpoint(0));
+    let checkpoints = client
+        .stream_checkpoints_with_config(body, fast_config())
+        .take(9)
+        .map_ok(|checkpoint| checkpoint.checkpoint.unwrap().sequence_number.unwrap())
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(checkpoints, (0..=8).collect::<Vec<_>>());
+
+    let state = server.state.lock().unwrap();
+    assert_eq!(
+        state.calls,
+        [
+            "get_service_info",
+            "list_checkpoints",
+            "subscribe_checkpoints",
+            "list_checkpoints"
+        ]
+    );
+    assert_eq!(state.checkpoint_requests[0].body.end_checkpoint, Some(6));
+    assert_eq!(state.checkpoint_requests[1].body.start_checkpoint, Some(6));
+    assert_eq!(state.checkpoint_requests[1].body.end_checkpoint, Some(8));
+    assert_eq!(state.checkpoint_subscriptions.len(), 1);
+    assert_eq!(
+        state.checkpoint_subscriptions[0].body.read_mask,
+        Some(prost_types::FieldMask {
+            paths: vec!["sequence_number".to_owned()],
+        })
+    );
+    assert_eq!(
+        state.checkpoint_subscriptions[0].body.filter,
+        Some(proto::TransactionFilter::default())
+    );
+    drop(state);
+
+    let observations = observations.lock().unwrap();
+    assert_eq!(observations.len(), 4);
+    assert!(
+        observations
+            .iter()
+            .any(|observation| observation.path.contains("GetServiceInfo"))
+    );
+    assert!(
+        observations
+            .iter()
+            .any(|observation| observation.path.contains("Subscribe"))
+    );
+    assert!(
+        observations
+            .iter()
+            .any(|observation| observation.path.contains("List"))
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_start_preserves_stream_fields_and_internal_page_limit() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([
+        Ok(service_info(0)),
+        Ok(service_info(0)),
+        Ok(service_info(0)),
+    ]);
+    server.push_checkpoint_lists([
+        StreamScript::frames([Ok(checkpoint_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(1), 1, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CheckpointBound),
+            )),
+        ]),
+    ]);
+    server.push_transaction_lists([
+        StreamScript::frames([Ok(transaction_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(1), 1, None)),
+            Ok(transaction_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    server.push_event_lists([
+        StreamScript::frames([Ok(event_list_frame(
+            None,
+            0,
+            Some(proto::QueryEndReason::CheckpointBound),
+        ))]),
+        StreamScript::frames([
+            Ok(event_list_frame(Some(1), 1, None)),
+            Ok(event_list_frame(
+                None,
+                2,
+                Some(proto::QueryEndReason::CursorBound),
+            )),
+        ]),
+    ]);
+    server.push_checkpoint_subscriptions([StreamScript::frames([Ok(checkpoint_live_frame(
+        Some(2),
+        2,
+    ))])]);
+    server.push_transaction_subscriptions([StreamScript::frames([Ok(transaction_live_frame(
+        Some(2),
+        2,
+    ))])]);
+    server.push_event_subscriptions([StreamScript::frames([Ok(event_live_frame(Some(2), 2))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+
+    let mut config = fast_config();
+    config.list_page_limit = Some(7);
+    let checkpoint_frames = client
+        .stream_checkpoints_with_config(
+            CheckpointStreamRequest::new()
+                .with_read_mask(prost_types::FieldMask {
+                    paths: vec!["digest".to_owned(), "sequence_number".to_owned()],
+                })
+                .with_filter(proto::TransactionFilter::default())
+                .with_start(CheckpointStreamStart::Checkpoint(0)),
+            config.clone(),
+        )
+        .take(3)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(checkpoint_frames[0].checkpoint.is_none());
+    assert_eq!(
+        checkpoint_frames[1]
+            .checkpoint
+            .as_ref()
+            .unwrap()
+            .sequence_number,
+        Some(1)
+    );
+
+    let transaction_frames = client
+        .stream_transactions_with_config(
+            TransactionStreamRequest::new()
+                .with_read_mask(prost_types::FieldMask {
+                    paths: vec![
+                        "digest".to_owned(),
+                        "checkpoint".to_owned(),
+                        "transaction_index".to_owned(),
+                    ],
+                })
+                .with_filter(proto::TransactionFilter::default())
+                .with_start(TransactionStreamStart::Checkpoint(0)),
+            config.clone(),
+        )
+        .take(3)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(transaction_frames[0].transaction.is_none());
+    let transaction = transaction_frames[1].transaction.as_ref().unwrap();
+    assert_eq!(transaction.checkpoint, Some(1));
+    assert_eq!(transaction.transaction_index, Some(0));
+
+    let event_frames = client
+        .stream_events_with_config(
+            EventStreamRequest::new()
+                .with_read_mask(prost_types::FieldMask {
+                    paths: vec![
+                        "event_type".to_owned(),
+                        "checkpoint".to_owned(),
+                        "transaction_index".to_owned(),
+                        "event_index".to_owned(),
+                    ],
+                })
+                .with_filter(proto::EventFilter::default())
+                .with_start(EventStreamStart::Checkpoint(0)),
+            config,
+        )
+        .take(3)
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(event_frames[0].event.is_none());
+    let event = event_frames[1].event.as_ref().unwrap();
+    assert_eq!(event.checkpoint, Some(1));
+    assert_eq!(event.transaction_index, Some(0));
+    assert_eq!(event.event_index, Some(0));
+
+    let state = server.state.lock().unwrap();
+    for (start_checkpoint, end_checkpoint, options) in [
+        (
+            state.checkpoint_requests[0].body.start_checkpoint,
+            state.checkpoint_requests[0].body.end_checkpoint,
+            state.checkpoint_requests[0].body.options.as_ref().unwrap(),
+        ),
+        (
+            state.transaction_requests[0].body.start_checkpoint,
+            state.transaction_requests[0].body.end_checkpoint,
+            state.transaction_requests[0].body.options.as_ref().unwrap(),
+        ),
+        (
+            state.event_requests[0].body.start_checkpoint,
+            state.event_requests[0].body.end_checkpoint,
+            state.event_requests[0].body.options.as_ref().unwrap(),
+        ),
+    ] {
+        assert_eq!(start_checkpoint, Some(0));
+        assert_eq!(end_checkpoint, Some(1));
+        assert_eq!(options.limit, Some(7));
+        assert!(options.ordering.is_none());
+    }
+    let checkpoint_recovery = &state.checkpoint_requests[1].body;
+    assert_eq!(checkpoint_recovery.start_checkpoint, Some(1));
+    assert_eq!(checkpoint_recovery.end_checkpoint, Some(3));
+    let checkpoint_recovery_options = checkpoint_recovery.options.as_ref().unwrap();
+    assert!(checkpoint_recovery_options.after.is_none());
+    assert!(checkpoint_recovery_options.before.is_none());
+    assert_eq!(checkpoint_recovery_options.limit, Some(7));
+    assert!(checkpoint_recovery_options.ordering.is_none());
+    for (start_checkpoint, end_checkpoint, options) in [
+        (
+            state.transaction_requests[1].body.start_checkpoint,
+            state.transaction_requests[1].body.end_checkpoint,
+            state.transaction_requests[1].body.options.as_ref().unwrap(),
+        ),
+        (
+            state.event_requests[1].body.start_checkpoint,
+            state.event_requests[1].body.end_checkpoint,
+            state.event_requests[1].body.options.as_ref().unwrap(),
+        ),
+    ] {
+        assert!(start_checkpoint.is_none());
+        assert!(end_checkpoint.is_none());
+        assert_eq!(options.after, Some(bytes(0)));
+        assert_eq!(options.before, Some(bytes(2)));
+        assert_eq!(options.limit, Some(7));
+        assert!(options.ordering.is_none());
+    }
+    assert_eq!(
+        state.checkpoint_subscriptions[0].body.read_mask,
+        state.checkpoint_requests[0].body.read_mask
+    );
+    assert_eq!(
+        state.checkpoint_subscriptions[0].body.filter,
+        state.checkpoint_requests[0].body.filter
+    );
+    assert_eq!(
+        state.transaction_subscriptions[0].body.read_mask,
+        state.transaction_requests[0].body.read_mask
+    );
+    assert_eq!(
+        state.transaction_subscriptions[0].body.filter,
+        state.transaction_requests[0].body.filter
+    );
+    assert_eq!(
+        state.event_subscriptions[0].body.read_mask,
+        state.event_requests[0].body.read_mask
+    );
+    assert_eq!(
+        state.event_subscriptions[0].body.filter,
+        state.event_requests[0].body.filter
+    );
+}
+
+#[tokio::test]
+async fn first_post_history_subscription_requires_checkpoint_coverage() {
+    let (server, _calls) = ScriptedStreamServer::new();
+    server.push_service_infos([Ok(service_info(5))]);
+    let mut invalid_boundary = event_live_frame(None, 6);
+    invalid_boundary.watermark.as_mut().unwrap().checkpoint = None;
+    server.push_event_subscriptions([StreamScript::frames([Ok(invalid_boundary)])]);
+    server.push_event_lists([StreamScript::frames([Ok(event_list_frame(
+        None,
+        5,
+        Some(proto::QueryEndReason::CheckpointBound),
+    ))])]);
+    let address = spawn_server(server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_events_with_config(
+        EventStreamRequest::new()
+            .with_read_mask(event_identity_mask())
+            .with_start(EventStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+
+    let history = stream.next().await.unwrap().unwrap();
+    assert_eq!(history.cursor, bytes(5));
+    assert_eq!(history.covered_checkpoint, Some(5));
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::DataLoss);
+    assert_eq!(
+        status.message(),
+        "subscription initial frame is missing checkpoint coverage"
+    );
+    assert!(stream.next().await.is_none());
+    let state = server.state.lock().unwrap();
+    assert_eq!(state.event_subscriptions.len(), 1);
+    assert_eq!(state.event_requests.len(), 1);
+}
+
+#[tokio::test]
+async fn maximum_service_info_or_new_subscription_checkpoint_is_out_of_range() {
+    let (service_info_server, _calls) = ScriptedStreamServer::new();
+    service_info_server.push_service_infos([Ok(service_info(u64::MAX))]);
+    let address = spawn_server(service_info_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_checkpoints_with_config(
+        CheckpointStreamRequest::new()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_start(CheckpointStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::OutOfRange);
+    assert!(
+        service_info_server
+            .state
+            .lock()
+            .unwrap()
+            .checkpoint_requests
+            .is_empty()
+    );
+    assert!(
+        service_info_server
+            .state
+            .lock()
+            .unwrap()
+            .checkpoint_subscriptions
+            .is_empty()
+    );
+
+    let (new_subscription_server, _calls) = ScriptedStreamServer::new();
+    new_subscription_server.push_service_infos([Ok(service_info(0))]);
+    new_subscription_server.push_checkpoint_subscriptions([StreamScript::frames([Ok(
+        checkpoint_live_frame(None, u64::MAX),
+    )])]);
+    new_subscription_server.push_checkpoint_lists([StreamScript::frames([Ok(
+        checkpoint_list_frame(None, 0, Some(proto::QueryEndReason::CheckpointBound)),
+    )])]);
+    let address = spawn_server(new_subscription_server.clone()).await;
+    let (client, _observations) = observed_client(address);
+    let stream = client.stream_checkpoints_with_config(
+        CheckpointStreamRequest::new()
+            .with_read_mask(checkpoint_identity_mask())
+            .with_filter(proto::TransactionFilter::default())
+            .with_start(CheckpointStreamStart::Checkpoint(0)),
+        fast_config(),
+    );
+    futures::pin_mut!(stream);
+    let progress = stream.next().await.unwrap().unwrap();
+    assert!(progress.checkpoint.is_none());
+    assert_eq!(progress.cursor, 0);
+    let status = stream.next().await.unwrap().unwrap_err();
+    assert_eq!(status.code(), tonic::Code::OutOfRange);
+    assert_eq!(
+        new_subscription_server
+            .state
+            .lock()
+            .unwrap()
+            .checkpoint_requests
+            .len(),
+        1
+    );
+}

--- a/crates/sui-rpc/tests/ledger_streams/support.rs
+++ b/crates/sui-rpc/tests/ledger_streams/support.rs
@@ -1,0 +1,546 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use futures::StreamExt;
+use prost::bytes::Bytes;
+use proto::ledger_service_server::LedgerService;
+use proto::ledger_service_server::LedgerServiceServer;
+use proto::subscription_service_server::SubscriptionService;
+use proto::subscription_service_server::SubscriptionServiceServer;
+use sui_rpc::Client;
+use sui_rpc::client::ListConfig;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+use tokio::sync::mpsc;
+use tonic::codegen::BoxStream;
+use tower::ServiceBuilder;
+
+pub(crate) const STREAM_DROP_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug)]
+pub(crate) struct HttpObservation {
+    pub(crate) path: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct CapturedRequest<T> {
+    pub(crate) body: T,
+}
+
+pub(crate) enum StreamScript<T> {
+    DispatchError(tonic::Status),
+    Frames(Vec<Result<T, tonic::Status>>),
+    Channel(mpsc::UnboundedReceiver<Result<T, tonic::Status>>),
+}
+
+impl<T> StreamScript<T> {
+    pub(crate) fn frames(frames: impl IntoIterator<Item = Result<T, tonic::Status>>) -> Self {
+        Self::Frames(frames.into_iter().collect())
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ScriptState {
+    pub(crate) service_infos: VecDeque<Result<proto::GetServiceInfoResponse, tonic::Status>>,
+    pub(crate) list_checkpoints: VecDeque<StreamScript<proto::ListCheckpointsResponse>>,
+    pub(crate) list_transactions: VecDeque<StreamScript<proto::ListTransactionsResponse>>,
+    pub(crate) list_events: VecDeque<StreamScript<proto::ListEventsResponse>>,
+    pub(crate) subscribe_checkpoints: VecDeque<StreamScript<proto::SubscribeCheckpointsResponse>>,
+    pub(crate) subscribe_transactions: VecDeque<StreamScript<proto::SubscribeTransactionsResponse>>,
+    pub(crate) subscribe_events: VecDeque<StreamScript<proto::SubscribeEventsResponse>>,
+    pub(crate) response_delay: Duration,
+    pub(crate) service_info_requests: Vec<CapturedRequest<proto::GetServiceInfoRequest>>,
+    pub(crate) checkpoint_requests: Vec<CapturedRequest<proto::ListCheckpointsRequest>>,
+    pub(crate) transaction_requests: Vec<CapturedRequest<proto::ListTransactionsRequest>>,
+    pub(crate) event_requests: Vec<CapturedRequest<proto::ListEventsRequest>>,
+    pub(crate) checkpoint_subscriptions: Vec<CapturedRequest<proto::SubscribeCheckpointsRequest>>,
+    pub(crate) transaction_subscriptions: Vec<CapturedRequest<proto::SubscribeTransactionsRequest>>,
+    pub(crate) event_subscriptions: Vec<CapturedRequest<proto::SubscribeEventsRequest>>,
+    pub(crate) calls: Vec<&'static str>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ScriptedStreamServer {
+    pub(crate) state: Arc<Mutex<ScriptState>>,
+    pub(crate) call_tx: mpsc::UnboundedSender<&'static str>,
+}
+
+impl ScriptedStreamServer {
+    pub(crate) fn new() -> (Self, mpsc::UnboundedReceiver<&'static str>) {
+        let (call_tx, call_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                state: Arc::new(Mutex::new(ScriptState::default())),
+                call_tx,
+            },
+            call_rx,
+        )
+    }
+
+    pub(crate) fn push_checkpoint_lists(
+        &self,
+        scripts: impl IntoIterator<Item = StreamScript<proto::ListCheckpointsResponse>>,
+    ) {
+        self.state.lock().unwrap().list_checkpoints.extend(scripts);
+    }
+
+    pub(crate) fn push_transaction_lists(
+        &self,
+        scripts: impl IntoIterator<Item = StreamScript<proto::ListTransactionsResponse>>,
+    ) {
+        self.state.lock().unwrap().list_transactions.extend(scripts);
+    }
+
+    pub(crate) fn push_event_lists(
+        &self,
+        scripts: impl IntoIterator<Item = StreamScript<proto::ListEventsResponse>>,
+    ) {
+        self.state.lock().unwrap().list_events.extend(scripts);
+    }
+}
+
+pub(crate) fn scripted_response<T: Send + 'static>(
+    script: StreamScript<T>,
+) -> Result<tonic::Response<BoxStream<T>>, tonic::Status> {
+    match script {
+        StreamScript::DispatchError(status) => Err(status),
+        StreamScript::Frames(frames) => Ok(tonic::Response::new(Box::pin(futures::stream::iter(
+            frames,
+        )))),
+        StreamScript::Channel(receiver) => {
+            let stream = futures::stream::unfold(receiver, |mut receiver| async move {
+                receiver.recv().await.map(|item| (item, receiver))
+            });
+            Ok(tonic::Response::new(Box::pin(stream)))
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl LedgerService for ScriptedStreamServer {
+    async fn get_service_info(
+        &self,
+        request: tonic::Request<proto::GetServiceInfoRequest>,
+    ) -> Result<tonic::Response<proto::GetServiceInfoResponse>, tonic::Status> {
+        let (script, response_delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push("get_service_info");
+            state.service_info_requests.push(CapturedRequest {
+                body: request.into_inner(),
+            });
+            let script = state
+                .service_infos
+                .pop_front()
+                .expect("missing get_service_info script");
+            (script, state.response_delay)
+        };
+        let _ = self.call_tx.send("get_service_info");
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
+        script.map(tonic::Response::new)
+    }
+
+    async fn list_checkpoints(
+        &self,
+        request: tonic::Request<proto::ListCheckpointsRequest>,
+    ) -> Result<tonic::Response<BoxStream<proto::ListCheckpointsResponse>>, tonic::Status> {
+        let (script, response_delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push("list_checkpoints");
+            state.checkpoint_requests.push(CapturedRequest {
+                body: request.into_inner(),
+            });
+            let script = state
+                .list_checkpoints
+                .pop_front()
+                .expect("missing list_checkpoints script");
+            (script, state.response_delay)
+        };
+        let _ = self.call_tx.send("list_checkpoints");
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
+        scripted_response(script)
+    }
+
+    async fn list_transactions(
+        &self,
+        request: tonic::Request<proto::ListTransactionsRequest>,
+    ) -> Result<tonic::Response<BoxStream<proto::ListTransactionsResponse>>, tonic::Status> {
+        let (script, response_delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push("list_transactions");
+            state.transaction_requests.push(CapturedRequest {
+                body: request.into_inner(),
+            });
+            let script = state
+                .list_transactions
+                .pop_front()
+                .expect("missing list_transactions script");
+            (script, state.response_delay)
+        };
+        let _ = self.call_tx.send("list_transactions");
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
+        scripted_response(script)
+    }
+
+    async fn list_events(
+        &self,
+        request: tonic::Request<proto::ListEventsRequest>,
+    ) -> Result<tonic::Response<BoxStream<proto::ListEventsResponse>>, tonic::Status> {
+        let (script, response_delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push("list_events");
+            state.event_requests.push(CapturedRequest {
+                body: request.into_inner(),
+            });
+            let script = state
+                .list_events
+                .pop_front()
+                .expect("missing list_events script");
+            (script, state.response_delay)
+        };
+        let _ = self.call_tx.send("list_events");
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
+        scripted_response(script)
+    }
+}
+
+#[tonic::async_trait]
+impl SubscriptionService for ScriptedStreamServer {
+    async fn subscribe_checkpoints(
+        &self,
+        request: tonic::Request<proto::SubscribeCheckpointsRequest>,
+    ) -> Result<tonic::Response<BoxStream<proto::SubscribeCheckpointsResponse>>, tonic::Status>
+    {
+        let (script, response_delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push("subscribe_checkpoints");
+            state.checkpoint_subscriptions.push(CapturedRequest {
+                body: request.into_inner(),
+            });
+            let script = state
+                .subscribe_checkpoints
+                .pop_front()
+                .expect("missing subscribe_checkpoints script");
+            (script, state.response_delay)
+        };
+        let _ = self.call_tx.send("subscribe_checkpoints");
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
+        scripted_response(script)
+    }
+
+    async fn subscribe_transactions(
+        &self,
+        request: tonic::Request<proto::SubscribeTransactionsRequest>,
+    ) -> Result<tonic::Response<BoxStream<proto::SubscribeTransactionsResponse>>, tonic::Status>
+    {
+        let (script, response_delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push("subscribe_transactions");
+            state.transaction_subscriptions.push(CapturedRequest {
+                body: request.into_inner(),
+            });
+            let script = state
+                .subscribe_transactions
+                .pop_front()
+                .expect("missing subscribe_transactions script");
+            (script, state.response_delay)
+        };
+        let _ = self.call_tx.send("subscribe_transactions");
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
+        scripted_response(script)
+    }
+
+    async fn subscribe_events(
+        &self,
+        request: tonic::Request<proto::SubscribeEventsRequest>,
+    ) -> Result<tonic::Response<BoxStream<proto::SubscribeEventsResponse>>, tonic::Status> {
+        let (script, response_delay) = {
+            let mut state = self.state.lock().unwrap();
+            state.calls.push("subscribe_events");
+            state.event_subscriptions.push(CapturedRequest {
+                body: request.into_inner(),
+            });
+            let script = state
+                .subscribe_events
+                .pop_front()
+                .expect("missing subscribe_events script");
+            (script, state.response_delay)
+        };
+        let _ = self.call_tx.send("subscribe_events");
+        if !response_delay.is_zero() {
+            tokio::time::sleep(response_delay).await;
+        }
+        scripted_response(script)
+    }
+}
+
+pub(crate) async fn spawn_server(server: ScriptedStreamServer) -> std::net::SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind scripted server listener");
+    let address = listener.local_addr().expect("scripted server address");
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(LedgerServiceServer::new(server.clone()))
+            .add_service(SubscriptionServiceServer::new(server))
+            .serve_with_incoming(tonic::transport::server::TcpIncoming::from(listener))
+            .await
+            .expect("scripted server failed");
+    });
+    tokio::task::yield_now().await;
+    address
+}
+
+pub(crate) fn observed_client(
+    address: std::net::SocketAddr,
+) -> (Client, Arc<Mutex<Vec<HttpObservation>>>) {
+    let observations = Arc::new(Mutex::new(Vec::new()));
+    let layer_observations = observations.clone();
+    let layer = ServiceBuilder::new().map_request(move |request: http::Request<_>| {
+        layer_observations.lock().unwrap().push(HttpObservation {
+            path: request.uri().path().to_owned(),
+        });
+        request
+    });
+    let client = Client::new(format!("http://{address}"))
+        .expect("scripted client")
+        .request_layer(layer);
+    (client, observations)
+}
+
+pub(crate) async fn next_scripted_call(
+    calls: &mut mpsc::UnboundedReceiver<&'static str>,
+) -> &'static str {
+    tokio::time::timeout(Duration::from_secs(2), calls.recv())
+        .await
+        .expect("timed out waiting for scripted RPC call")
+        .expect("scripted RPC call channel closed")
+}
+
+pub(crate) fn bytes(value: u64) -> Bytes {
+    Bytes::from(format!("c{value}"))
+}
+
+pub(crate) fn watermark(value: u64) -> proto::Watermark {
+    let mut watermark = proto::Watermark::default();
+    watermark.cursor = Some(bytes(value));
+    watermark.checkpoint = Some(value);
+    watermark
+}
+pub(crate) fn watermark_at(cursor: u64, checkpoint: u64) -> proto::Watermark {
+    let mut watermark = watermark(cursor);
+    watermark.checkpoint = Some(checkpoint);
+    watermark
+}
+
+pub(crate) fn query_end(reason: proto::QueryEndReason) -> proto::QueryEnd {
+    let mut end = proto::QueryEnd::default();
+    end.reason = Some(reason as i32);
+    end
+}
+
+pub(crate) fn checkpoint(value: u64) -> proto::Checkpoint {
+    let mut checkpoint = proto::Checkpoint::default();
+    checkpoint.sequence_number = Some(value);
+    checkpoint
+}
+
+pub(crate) fn transaction(value: u64) -> proto::ExecutedTransaction {
+    let mut transaction = proto::ExecutedTransaction::default();
+    transaction.digest = Some(format!("tx-{value}"));
+    transaction.checkpoint = Some(value);
+    transaction.transaction_index = Some(0);
+    transaction
+}
+
+pub(crate) fn event(value: u64) -> proto::Event {
+    let mut event = proto::Event::default();
+    event.event_type = Some(format!("event-{value}"));
+    event.checkpoint = Some(value);
+    event.transaction_index = Some(0);
+    event.event_index = Some(0);
+    event
+}
+pub(crate) fn checkpoint_list_frame(
+    item: Option<u64>,
+    cursor: u64,
+    reason: Option<proto::QueryEndReason>,
+) -> proto::ListCheckpointsResponse {
+    let mut response = proto::ListCheckpointsResponse::default();
+    response.checkpoint = item.map(checkpoint);
+    response.watermark = Some(watermark(cursor));
+    response.end = reason.map(query_end);
+    response
+}
+
+pub(crate) fn transaction_list_frame(
+    item: Option<u64>,
+    cursor: u64,
+    reason: Option<proto::QueryEndReason>,
+) -> proto::ListTransactionsResponse {
+    let mut response = proto::ListTransactionsResponse::default();
+    response.transaction = item.map(transaction);
+    response.watermark = Some(watermark(cursor));
+    response.end = reason.map(query_end);
+    response
+}
+
+pub(crate) fn event_list_frame(
+    item: Option<u64>,
+    cursor: u64,
+    reason: Option<proto::QueryEndReason>,
+) -> proto::ListEventsResponse {
+    let mut response = proto::ListEventsResponse::default();
+    response.event = item.map(event);
+    response.watermark = Some(watermark(cursor));
+    response.end = reason.map(query_end);
+    response
+}
+
+pub(crate) fn event_positioned_list_frame(
+    item: Option<proto::Event>,
+    cursor: u64,
+    checkpoint: u64,
+    reason: Option<proto::QueryEndReason>,
+) -> proto::ListEventsResponse {
+    let mut response = proto::ListEventsResponse::default();
+    response.event = item;
+    response.watermark = Some(watermark_at(cursor, checkpoint));
+    response.end = reason.map(query_end);
+    response
+}
+pub(crate) fn bounded_checkpoint_scripts() -> Vec<StreamScript<proto::ListCheckpointsResponse>> {
+    vec![
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(Some(2), 2, None)),
+            Ok(checkpoint_list_frame(
+                Some(3),
+                3,
+                Some(proto::QueryEndReason::ItemLimit),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(checkpoint_list_frame(None, 5, None)),
+            Ok(checkpoint_list_frame(Some(6), 6, None)),
+            Ok(checkpoint_list_frame(Some(7), 7, None)),
+            Ok(checkpoint_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::LedgerTip),
+            )),
+        ]),
+    ]
+}
+
+pub(crate) fn bounded_transaction_scripts() -> Vec<StreamScript<proto::ListTransactionsResponse>> {
+    vec![
+        StreamScript::frames([
+            Ok(transaction_list_frame(Some(2), 2, None)),
+            Ok(transaction_list_frame(
+                Some(3),
+                3,
+                Some(proto::QueryEndReason::ItemLimit),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(transaction_list_frame(None, 5, None)),
+            Ok(transaction_list_frame(Some(6), 6, None)),
+            Ok(transaction_list_frame(Some(7), 7, None)),
+            Ok(transaction_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::LedgerTip),
+            )),
+        ]),
+    ]
+}
+
+pub(crate) fn bounded_event_scripts() -> Vec<StreamScript<proto::ListEventsResponse>> {
+    vec![
+        StreamScript::frames([
+            Ok(event_list_frame(Some(2), 2, None)),
+            Ok(event_list_frame(
+                Some(3),
+                3,
+                Some(proto::QueryEndReason::ItemLimit),
+            )),
+        ]),
+        StreamScript::frames([
+            Ok(event_list_frame(None, 5, None)),
+            Ok(event_list_frame(Some(6), 6, None)),
+            Ok(event_list_frame(Some(7), 7, None)),
+            Ok(event_list_frame(
+                None,
+                7,
+                Some(proto::QueryEndReason::LedgerTip),
+            )),
+        ]),
+    ]
+}
+pub(crate) fn checkpoint_identity_mask() -> prost_types::FieldMask {
+    prost_types::FieldMask {
+        paths: vec!["sequence_number".to_owned()],
+    }
+}
+
+pub(crate) fn transaction_identity_mask() -> prost_types::FieldMask {
+    prost_types::FieldMask {
+        paths: vec!["checkpoint".to_owned(), "transaction_index".to_owned()],
+    }
+}
+
+pub(crate) fn event_identity_mask() -> prost_types::FieldMask {
+    prost_types::FieldMask {
+        paths: vec![
+            "checkpoint".to_owned(),
+            "transaction_index".to_owned(),
+            "event_index".to_owned(),
+        ],
+    }
+}
+
+pub(crate) fn fast_list_config() -> ListConfig {
+    let mut config = ListConfig::default();
+    config.base_retry_delay = Duration::ZERO;
+    config.max_retry_delay = Duration::ZERO;
+    config.retry_jitter = Duration::ZERO;
+    config
+}
+
+pub(crate) fn bounded_event_request() -> proto::ListEventsRequest {
+    proto::ListEventsRequest::default()
+        .with_read_mask(event_identity_mask())
+        .with_end_checkpoint(10)
+}
+pub(crate) async fn first_list_event_error(
+    client: &Client,
+    request_body: proto::ListEventsRequest,
+    config: ListConfig,
+) -> tonic::Status {
+    let stream = client.list_events_with_config(request_body, config);
+    futures::pin_mut!(stream);
+    let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for terminal List error")
+        .unwrap()
+        .unwrap_err();
+    assert!(
+        tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("timed out waiting for List termination")
+            .is_none()
+    );
+    status
+}

--- a/crates/sui-rpc/tests/ledger_streams/support.rs
+++ b/crates/sui-rpc/tests/ledger_streams/support.rs
@@ -10,6 +10,9 @@ use proto::ledger_service_server::LedgerServiceServer;
 use proto::subscription_service_server::SubscriptionService;
 use proto::subscription_service_server::SubscriptionServiceServer;
 use sui_rpc::Client;
+use sui_rpc::client::EventStreamRequest;
+use sui_rpc::client::LedgerStreamConfig;
+use sui_rpc::client::LedgerStreamEvent;
 use sui_rpc::client::ListConfig;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 use tokio::sync::mpsc;
@@ -78,6 +81,17 @@ impl ScriptedStreamServer {
         )
     }
 
+    pub(crate) fn set_response_delay(&self, response_delay: Duration) {
+        self.state.lock().unwrap().response_delay = response_delay;
+    }
+
+    pub(crate) fn push_service_infos(
+        &self,
+        scripts: impl IntoIterator<Item = Result<proto::GetServiceInfoResponse, tonic::Status>>,
+    ) {
+        self.state.lock().unwrap().service_infos.extend(scripts);
+    }
+
     pub(crate) fn push_checkpoint_lists(
         &self,
         scripts: impl IntoIterator<Item = StreamScript<proto::ListCheckpointsResponse>>,
@@ -97,6 +111,35 @@ impl ScriptedStreamServer {
         scripts: impl IntoIterator<Item = StreamScript<proto::ListEventsResponse>>,
     ) {
         self.state.lock().unwrap().list_events.extend(scripts);
+    }
+
+    pub(crate) fn push_checkpoint_subscriptions(
+        &self,
+        scripts: impl IntoIterator<Item = StreamScript<proto::SubscribeCheckpointsResponse>>,
+    ) {
+        self.state
+            .lock()
+            .unwrap()
+            .subscribe_checkpoints
+            .extend(scripts);
+    }
+
+    pub(crate) fn push_transaction_subscriptions(
+        &self,
+        scripts: impl IntoIterator<Item = StreamScript<proto::SubscribeTransactionsResponse>>,
+    ) {
+        self.state
+            .lock()
+            .unwrap()
+            .subscribe_transactions
+            .extend(scripts);
+    }
+
+    pub(crate) fn push_event_subscriptions(
+        &self,
+        scripts: impl IntoIterator<Item = StreamScript<proto::SubscribeEventsResponse>>,
+    ) {
+        self.state.lock().unwrap().subscribe_events.extend(scripts);
     }
 }
 
@@ -303,6 +346,22 @@ pub(crate) async fn spawn_server(server: ScriptedStreamServer) -> std::net::Sock
     address
 }
 
+pub(crate) async fn spawn_ledger_only_server(server: ScriptedStreamServer) -> std::net::SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind scripted server listener");
+    let address = listener.local_addr().expect("scripted server address");
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(LedgerServiceServer::new(server))
+            .serve_with_incoming(tonic::transport::server::TcpIncoming::from(listener))
+            .await
+            .expect("scripted server failed");
+    });
+    tokio::task::yield_now().await;
+    address
+}
+
 pub(crate) fn observed_client(
     address: std::net::SocketAddr,
 ) -> (Client, Arc<Mutex<Vec<HttpObservation>>>) {
@@ -320,6 +379,19 @@ pub(crate) fn observed_client(
     (client, observations)
 }
 
+pub(crate) fn recording_config(
+    config: LedgerStreamConfig,
+) -> (
+    LedgerStreamConfig,
+    mpsc::UnboundedReceiver<LedgerStreamEvent>,
+) {
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let config = config.with_observer(move |event| {
+        let _ = event_tx.send(event);
+    });
+    (config, event_rx)
+}
+
 pub(crate) async fn next_scripted_call(
     calls: &mut mpsc::UnboundedReceiver<&'static str>,
 ) -> &'static str {
@@ -327,6 +399,12 @@ pub(crate) async fn next_scripted_call(
         .await
         .expect("timed out waiting for scripted RPC call")
         .expect("scripted RPC call channel closed")
+}
+
+pub(crate) fn service_info(checkpoint_height: u64) -> proto::GetServiceInfoResponse {
+    let mut response = proto::GetServiceInfoResponse::default();
+    response.checkpoint_height = Some(checkpoint_height);
+    response
 }
 
 pub(crate) fn bytes(value: u64) -> Bytes {
@@ -373,6 +451,32 @@ pub(crate) fn event(value: u64) -> proto::Event {
     event.event_index = Some(0);
     event
 }
+pub(crate) fn transaction_at(
+    checkpoint: u64,
+    transaction_index: u64,
+    digest: &str,
+) -> proto::ExecutedTransaction {
+    let mut transaction = proto::ExecutedTransaction::default();
+    transaction.digest = Some(digest.to_owned());
+    transaction.checkpoint = Some(checkpoint);
+    transaction.transaction_index = Some(transaction_index);
+    transaction
+}
+
+pub(crate) fn event_at(
+    checkpoint: u64,
+    transaction_index: u64,
+    event_index: u32,
+    event_type: &str,
+) -> proto::Event {
+    let mut event = proto::Event::default();
+    event.event_type = Some(event_type.to_owned());
+    event.checkpoint = Some(checkpoint);
+    event.transaction_index = Some(transaction_index);
+    event.event_index = Some(event_index);
+    event
+}
+
 pub(crate) fn checkpoint_list_frame(
     item: Option<u64>,
     cursor: u64,
@@ -409,6 +513,45 @@ pub(crate) fn event_list_frame(
     response
 }
 
+pub(crate) fn checkpoint_live_frame(
+    item: Option<u64>,
+    cursor: u64,
+) -> proto::SubscribeCheckpointsResponse {
+    let mut response = proto::SubscribeCheckpointsResponse::default();
+    response.cursor = Some(cursor);
+    response.checkpoint = item.map(checkpoint);
+    response
+}
+
+pub(crate) fn transaction_live_frame(
+    item: Option<u64>,
+    cursor: u64,
+) -> proto::SubscribeTransactionsResponse {
+    let mut response = proto::SubscribeTransactionsResponse::default();
+    response.transaction = item.map(transaction);
+    response.watermark = Some(watermark(cursor));
+    response
+}
+
+pub(crate) fn event_live_frame(item: Option<u64>, cursor: u64) -> proto::SubscribeEventsResponse {
+    let mut response = proto::SubscribeEventsResponse::default();
+    response.event = item.map(event);
+    response.watermark = Some(watermark(cursor));
+    response
+}
+pub(crate) fn transaction_positioned_list_frame(
+    item: Option<proto::ExecutedTransaction>,
+    cursor: u64,
+    checkpoint: u64,
+    reason: Option<proto::QueryEndReason>,
+) -> proto::ListTransactionsResponse {
+    let mut response = proto::ListTransactionsResponse::default();
+    response.transaction = item;
+    response.watermark = Some(watermark_at(cursor, checkpoint));
+    response.end = reason.map(query_end);
+    response
+}
+
 pub(crate) fn event_positioned_list_frame(
     item: Option<proto::Event>,
     cursor: u64,
@@ -421,6 +564,29 @@ pub(crate) fn event_positioned_list_frame(
     response.end = reason.map(query_end);
     response
 }
+
+pub(crate) fn transaction_positioned_live_frame(
+    item: Option<proto::ExecutedTransaction>,
+    cursor: u64,
+    checkpoint: u64,
+) -> proto::SubscribeTransactionsResponse {
+    let mut response = proto::SubscribeTransactionsResponse::default();
+    response.transaction = item;
+    response.watermark = Some(watermark_at(cursor, checkpoint));
+    response
+}
+
+pub(crate) fn event_positioned_live_frame(
+    item: Option<proto::Event>,
+    cursor: u64,
+    checkpoint: u64,
+) -> proto::SubscribeEventsResponse {
+    let mut response = proto::SubscribeEventsResponse::default();
+    response.event = item;
+    response.watermark = Some(watermark_at(cursor, checkpoint));
+    response
+}
+
 pub(crate) fn bounded_checkpoint_scripts() -> Vec<StreamScript<proto::ListCheckpointsResponse>> {
     vec![
         StreamScript::frames([
@@ -511,6 +677,14 @@ pub(crate) fn event_identity_mask() -> prost_types::FieldMask {
     }
 }
 
+pub(crate) fn fast_config() -> LedgerStreamConfig {
+    let mut config = LedgerStreamConfig::default();
+    config.base_retry_delay = Duration::ZERO;
+    config.max_retry_delay = Duration::ZERO;
+    config.retry_jitter = Duration::ZERO;
+    config
+}
+
 pub(crate) fn fast_list_config() -> ListConfig {
     let mut config = ListConfig::default();
     config.base_retry_delay = Duration::ZERO;
@@ -524,6 +698,27 @@ pub(crate) fn bounded_event_request() -> proto::ListEventsRequest {
         .with_read_mask(event_identity_mask())
         .with_end_checkpoint(10)
 }
+pub(crate) async fn first_event_error(
+    client: &Client,
+    request_body: EventStreamRequest,
+    config: LedgerStreamConfig,
+) -> tonic::Status {
+    let stream = client.stream_events_with_config(request_body, config);
+    futures::pin_mut!(stream);
+    let status = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for terminal stream error")
+        .unwrap()
+        .unwrap_err();
+    assert!(
+        tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("timed out waiting for stream termination")
+            .is_none()
+    );
+    status
+}
+
 pub(crate) async fn first_list_event_error(
     client: &Client,
     request_body: proto::ListEventsRequest,


### PR DESCRIPTION
Resuming pagination with cursors and transitioning from pagination to subscriptions is tedious. Adding helpers to the SDK so clients don't have to implement it themselves.

Integrated it with Seal here as a proof of concept - https://github.com/MystenLabs/seal/pull/636

I tested it by having an agent try to break it, which is where the retry classification logic came from. 
