### PR TITLE
sui-rpc: add Client::with_num_connections to spread RPCs over several connections

### DIFF
--- a/crates/sui-rpc/src/client/mod.rs
+++ b/crates/sui-rpc/src/client/mod.rs
@@ -1,4 +1,8 @@
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
 use std::time::Duration;
 use tap::Pipe;
 use tonic::body::Body;
@@ -56,10 +60,11 @@ const DEFAULT_TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_TCP_KEEPALIVE_RETRIES: u32 = 3;
 const DEFAULT_HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
+const DEFAULT_NUM_CONNECTIONS: usize = 1;
 
-// All RPCs made through a `Client` (and all of its clones) are multiplexed
-// over a single HTTP/2 connection, so the connection-level receive window is
-// shared by every in-flight response. A streaming response that the
+// RPCs made through a `Client` (and all of its clones) are multiplexed over
+// its HTTP/2 connections, so each connection-level receive window is shared
+// by every in-flight response on that connection. A streaming response that the
 // application holds without polling pins up to a full stream window of that
 // shared budget; once the connection window is exhausted, every RPC on the
 // channel hangs indefinitely while TCP and HTTP/2 keepalives stay healthy.
@@ -72,8 +77,10 @@ const DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE: u32 = 64 * 1024 * 1024;
 
 /// A gRPC client for the Sui fullnode RPC interface.
 ///
-/// All RPCs made through a client and its clones are multiplexed over a
-/// single HTTP/2 connection.
+/// RPCs made through a client and its clones are multiplexed over a single
+/// HTTP/2 connection by default; see
+/// [`with_num_connections`](Client::with_num_connections) to spread them over
+/// several.
 ///
 /// # Timeouts and deadlines
 ///
@@ -97,9 +104,9 @@ const DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE: u32 = 64 * 1024 * 1024;
 /// connection fails with `DeadlineExceeded` instead of hanging forever.
 #[derive(Clone)]
 pub struct Client {
-    channel: tonic::transport::Channel,
+    transport: Transport,
 
-    // Everything other than the channel is only consulted when building a
+    // Everything other than the transport is only consulted when building a
     // per-service client or reconfiguring, so it lives behind an `Arc` to
     // keep `Client` itself small; it is cloned by value into futures
     // throughout the SDK. The `Endpoint` alone is over 500 bytes.
@@ -113,9 +120,98 @@ struct ClientConfig {
     headers: HeadersInterceptor,
     max_decoding_message_size: Option<usize>,
     body_idle_timeout: Option<Duration>,
+    num_connections: usize,
 
     /// Layer to apply to all RPC requests
     request_layer: Option<RequestLayer>,
+}
+
+/// The transport beneath a [`Client`]: a non-empty set of HTTP/2 connections
+/// to one endpoint, with each request assigned to the next connection in
+/// rotation.
+///
+/// A request is bound to a connection by `poll_ready` and dispatched to that
+/// same connection by the `call` that follows, so concurrent RPCs issued
+/// through one service client spread across the set instead of contending for
+/// a single connection's flow-control window and driver task.
+struct Transport {
+    connections: Arc<Vec<tonic::transport::Channel>>,
+
+    /// Shared by every clone, so the rotation advances across the whole
+    /// client rather than restarting per clone.
+    next: Arc<AtomicUsize>,
+
+    /// The connection `poll_ready` bound the next `call` to. It is held as a
+    /// `Channel` rather than an index because a ready channel owns a reserved
+    /// slot in its buffer that the paired `call` consumes, and that
+    /// reservation does not survive being cloned.
+    ready: Option<tonic::transport::Channel>,
+}
+
+impl Transport {
+    /// Open `num_connections` lazy connections to `endpoint`, all sharing its
+    /// configuration. Panics if `num_connections` is zero.
+    fn new(endpoint: &tonic::transport::Endpoint, num_connections: usize) -> Self {
+        assert!(
+            num_connections > 0,
+            "a client needs at least one connection"
+        );
+        Self {
+            connections: Arc::new(
+                (0..num_connections)
+                    .map(|_| endpoint.connect_lazy())
+                    .collect(),
+            ),
+            next: Arc::new(AtomicUsize::new(0)),
+            ready: None,
+        }
+    }
+}
+
+impl Clone for Transport {
+    /// Clones start unbound: a reserved buffer slot belongs to the clone that
+    /// acquired it and does not survive being copied.
+    fn clone(&self) -> Self {
+        Self {
+            connections: self.connections.clone(),
+            next: self.next.clone(),
+            ready: None,
+        }
+    }
+}
+
+impl Service<http::Request<Body>> for Transport {
+    type Response = http::Response<Body>;
+    type Error = tonic::transport::Error;
+    type Future = tonic::transport::channel::ResponseFuture;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.ready.is_none() {
+            let index = self.next.fetch_add(1, Ordering::Relaxed) % self.connections.len();
+            self.ready = Some(self.connections[index].clone());
+        }
+
+        let poll = self
+            .ready
+            .as_mut()
+            .expect("a connection was just bound")
+            .poll_ready(cx);
+
+        // Release a failed connection so the next attempt rotates on to a
+        // different one instead of retrying this one forever.
+        if matches!(poll, Poll::Ready(Err(_))) {
+            self.ready = None;
+        }
+
+        poll
+    }
+
+    fn call(&mut self, request: http::Request<Body>) -> Self::Future {
+        self.ready
+            .take()
+            .expect("service not ready; poll_ready must be called first")
+            .call(request)
+    }
 }
 
 impl Client {
@@ -137,8 +233,8 @@ impl Client {
     /// Build a client from a fully custom [`tonic::transport::Endpoint`].
     ///
     /// This bypasses every transport default that [`Client::new`] applies,
-    /// including the HTTP/2 flow-control windows that protect the shared
-    /// connection from starvation by stalled streaming responses. Prefer
+    /// including the HTTP/2 flow-control windows that protect a connection
+    /// from starvation by stalled streaming responses. Prefer
     /// [`Client::new`] plus the `with_*` configuration methods unless an
     /// endpoint setting is needed that the client does not expose. The
     /// idle-body watchdog (see [`Client::with_body_idle_timeout`]) is part of
@@ -152,15 +248,16 @@ impl Client {
     /// starve the whole connection.
     pub fn from_endpoint(endpoint: &tonic::transport::Endpoint) -> Self {
         let uri = endpoint.uri().clone();
-        let channel = endpoint.connect_lazy();
+        let transport = Transport::new(endpoint, DEFAULT_NUM_CONNECTIONS);
         Self {
-            channel,
+            transport,
             config: Arc::new(ClientConfig {
                 uri,
                 endpoint: endpoint.clone(),
                 headers: Default::default(),
                 max_decoding_message_size: None,
                 body_idle_timeout: Some(DEFAULT_BODY_IDLE_TIMEOUT),
+                num_connections: DEFAULT_NUM_CONNECTIONS,
                 request_layer: None,
             }),
         }
@@ -193,16 +290,17 @@ impl Client {
             .keep_alive_timeout(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT)
             .initial_stream_window_size(DEFAULT_HTTP2_STREAM_WINDOW_SIZE)
             .initial_connection_window_size(DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE);
-        let channel = endpoint.connect_lazy();
+        let transport = Transport::new(&endpoint, DEFAULT_NUM_CONNECTIONS);
 
         Ok(Self {
-            channel,
+            transport,
             config: Arc::new(ClientConfig {
                 uri,
                 endpoint,
                 headers: Default::default(),
                 max_decoding_message_size: None,
                 body_idle_timeout: Some(DEFAULT_BODY_IDLE_TIMEOUT),
+                num_connections: DEFAULT_NUM_CONNECTIONS,
                 request_layer: None,
             }),
         })
@@ -269,7 +367,35 @@ impl Client {
     pub fn with_response_headers_timeout(mut self, timeout: Duration) -> Self {
         let config = Arc::make_mut(&mut self.config);
         config.endpoint = config.endpoint.clone().timeout(timeout);
-        self.channel = config.endpoint.connect_lazy();
+        self.transport = Transport::new(&config.endpoint, config.num_connections);
+        self
+    }
+
+    /// Set how many HTTP/2 connections the client opens to the endpoint.
+    /// Defaults to 1; a count of 0 is treated as 1.
+    ///
+    /// Each RPC is assigned to the next connection in rotation, so concurrent
+    /// calls are spread evenly rather than sharing one connection's
+    /// flow-control window and driver task. A single connection's throughput
+    /// is bounded by that window and by the one task driving its multiplexed
+    /// streams, so workloads that keep many streams in flight at once (bulk
+    /// or streaming reads) can be limited by it well before the server is.
+    /// Every connection carries the same endpoint configuration, so the
+    /// window sizes described in
+    /// [`with_initial_connection_window_size`](Self::with_initial_connection_window_size)
+    /// apply to each one, and the client's total window budget scales with
+    /// the count.
+    ///
+    /// Connections are opened lazily and reconnect independently, and one
+    /// that cannot be established fails only the calls routed to it.
+    ///
+    /// This rebuilds the underlying channel, so it must be called before the
+    /// client is used or cloned; earlier clones keep the previous
+    /// configuration.
+    pub fn with_num_connections(mut self, num_connections: usize) -> Self {
+        let config = Arc::make_mut(&mut self.config);
+        config.num_connections = num_connections.max(1);
+        self.transport = Transport::new(&config.endpoint, config.num_connections);
         self
     }
 
@@ -287,18 +413,22 @@ impl Client {
     pub fn with_initial_stream_window_size(mut self, size: u32) -> Self {
         let config = Arc::make_mut(&mut self.config);
         config.endpoint = config.endpoint.clone().initial_stream_window_size(size);
-        self.channel = config.endpoint.connect_lazy();
+        self.transport = Transport::new(&config.endpoint, config.num_connections);
         self
     }
 
     /// Set the HTTP/2 connection-level receive window, in bytes.
     ///
-    /// This window is shared by every RPC multiplexed over the client's
-    /// single HTTP/2 connection, including all clones of the client. Response
-    /// data that the application has not yet read counts against it, so it
-    /// determines how many concurrently stalled streaming responses it takes
-    /// to starve the connection and hang every other RPC on it. Defaults to
-    /// 64 MiB (~32 stalled streams at the default 2 MiB stream window).
+    /// This window is shared by every RPC multiplexed over one of the
+    /// client's HTTP/2 connections, including those issued by clones of the
+    /// client. Response data that the application has not yet read counts
+    /// against it, so it determines how many concurrently stalled streaming
+    /// responses it takes to starve a connection and hang every other RPC on
+    /// it. Defaults to 64 MiB (~32 stalled streams at the default 2 MiB
+    /// stream window). The window applies per connection, so a client
+    /// configured with
+    /// [`with_num_connections`](Self::with_num_connections) has this much on
+    /// each.
     ///
     /// This rebuilds the underlying channel, so it must be called before the
     /// client is used or cloned; earlier clones keep the previous
@@ -306,7 +436,7 @@ impl Client {
     pub fn with_initial_connection_window_size(mut self, size: u32) -> Self {
         let config = Arc::make_mut(&mut self.config);
         config.endpoint = config.endpoint.clone().initial_connection_window_size(size);
-        self.channel = config.endpoint.connect_lazy();
+        self.transport = Transport::new(&config.endpoint, config.num_connections);
         self
     }
 
@@ -393,7 +523,7 @@ impl Client {
                     }
                     req
                 })
-                .service(self.channel.clone()),
+                .service(self.transport.clone()),
         );
 
         // Guard every response body with the idle-body watchdog, beneath any

--- a/crates/sui-rpc/src/client/mod.rs
+++ b/crates/sui-rpc/src/client/mod.rs
@@ -1,8 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
-use std::task::Context;
-use std::task::Poll;
 use std::time::Duration;
 use tap::Pipe;
 use tonic::body::Body;
@@ -104,9 +100,9 @@ const DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE: u32 = 64 * 1024 * 1024;
 /// connection fails with `DeadlineExceeded` instead of hanging forever.
 #[derive(Clone)]
 pub struct Client {
-    transport: Transport,
+    channel: tonic::transport::Channel,
 
-    // Everything other than the transport is only consulted when building a
+    // Everything other than the channel is only consulted when building a
     // per-service client or reconfiguring, so it lives behind an `Arc` to
     // keep `Client` itself small; it is cloned by value into futures
     // throughout the SDK. The `Endpoint` alone is over 500 bytes.
@@ -126,92 +122,32 @@ struct ClientConfig {
     request_layer: Option<RequestLayer>,
 }
 
-/// The transport beneath a [`Client`]: a non-empty set of HTTP/2 connections
-/// to one endpoint, with each request assigned to the next connection in
-/// rotation.
+/// Open `num_connections` lazy connections to `endpoint`, all sharing its
+/// configuration, and balance requests across them.
 ///
-/// A request is bound to a connection by `poll_ready` and dispatched to that
-/// same connection by the `call` that follows, so concurrent RPCs issued
-/// through one service client spread across the set instead of contending for
-/// a single connection's flow-control window and driver task.
-struct Transport {
-    connections: Arc<Vec<tonic::transport::Channel>>,
-
-    /// Shared by every clone, so the rotation advances across the whole
-    /// client rather than restarting per clone.
-    next: Arc<AtomicUsize>,
-
-    /// The connection `poll_ready` bound the next `call` to. It is held as a
-    /// `Channel` rather than an index because a ready channel owns a reserved
-    /// slot in its buffer that the paired `call` consumes, and that
-    /// reservation does not survive being cloned.
-    ready: Option<tonic::transport::Channel>,
-}
-
-impl Transport {
-    /// Open `num_connections` lazy connections to `endpoint`, all sharing its
-    /// configuration. Panics if `num_connections` is zero.
-    fn new(endpoint: &tonic::transport::Endpoint, num_connections: usize) -> Self {
-        assert!(
-            num_connections > 0,
-            "a client needs at least one connection"
-        );
-        Self {
-            connections: Arc::new(
-                (0..num_connections)
-                    .map(|_| endpoint.connect_lazy())
-                    .collect(),
-            ),
-            next: Arc::new(AtomicUsize::new(0)),
-            ready: None,
-        }
-    }
-}
-
-impl Clone for Transport {
-    /// Clones start unbound: a reserved buffer slot belongs to the clone that
-    /// acquired it and does not survive being copied.
-    fn clone(&self) -> Self {
-        Self {
-            connections: self.connections.clone(),
-            next: self.next.clone(),
-            ready: None,
-        }
-    }
-}
-
-impl Service<http::Request<Body>> for Transport {
-    type Response = http::Response<Body>;
-    type Error = tonic::transport::Error;
-    type Future = tonic::transport::channel::ResponseFuture;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if self.ready.is_none() {
-            let index = self.next.fetch_add(1, Ordering::Relaxed) % self.connections.len();
-            self.ready = Some(self.connections[index].clone());
-        }
-
-        let poll = self
-            .ready
-            .as_mut()
-            .expect("a connection was just bound")
-            .poll_ready(cx);
-
-        // Release a failed connection so the next attempt rotates on to a
-        // different one instead of retrying this one forever.
-        if matches!(poll, Poll::Ready(Err(_))) {
-            self.ready = None;
-        }
-
-        poll
+/// Each connection is inserted under its own key, because the balancer
+/// identifies backends by key and the endpoint is the same for all of them.
+/// The change sender is dropped once the set is populated: the set is fixed,
+/// and the balancer retains it after discovery ends.
+fn build_channel(
+    endpoint: &tonic::transport::Endpoint,
+    num_connections: usize,
+) -> tonic::transport::Channel {
+    if num_connections <= 1 {
+        return endpoint.connect_lazy();
     }
 
-    fn call(&mut self, request: http::Request<Body>) -> Self::Future {
-        self.ready
-            .take()
-            .expect("service not ready; poll_ready must be called first")
-            .call(request)
+    let (channel, changes) = tonic::transport::Channel::balance_channel::<usize>(num_connections);
+    for key in 0..num_connections {
+        changes
+            .try_send(tonic::transport::channel::Change::Insert(
+                key,
+                endpoint.clone(),
+            ))
+            .expect("change channel has capacity for every connection");
     }
+
+    channel
 }
 
 impl Client {
@@ -248,9 +184,9 @@ impl Client {
     /// starve the whole connection.
     pub fn from_endpoint(endpoint: &tonic::transport::Endpoint) -> Self {
         let uri = endpoint.uri().clone();
-        let transport = Transport::new(endpoint, DEFAULT_NUM_CONNECTIONS);
+        let channel = build_channel(endpoint, DEFAULT_NUM_CONNECTIONS);
         Self {
-            transport,
+            channel,
             config: Arc::new(ClientConfig {
                 uri,
                 endpoint: endpoint.clone(),
@@ -290,10 +226,10 @@ impl Client {
             .keep_alive_timeout(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT)
             .initial_stream_window_size(DEFAULT_HTTP2_STREAM_WINDOW_SIZE)
             .initial_connection_window_size(DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE);
-        let transport = Transport::new(&endpoint, DEFAULT_NUM_CONNECTIONS);
+        let channel = build_channel(&endpoint, DEFAULT_NUM_CONNECTIONS);
 
         Ok(Self {
-            transport,
+            channel,
             config: Arc::new(ClientConfig {
                 uri,
                 endpoint,
@@ -367,27 +303,30 @@ impl Client {
     pub fn with_response_headers_timeout(mut self, timeout: Duration) -> Self {
         let config = Arc::make_mut(&mut self.config);
         config.endpoint = config.endpoint.clone().timeout(timeout);
-        self.transport = Transport::new(&config.endpoint, config.num_connections);
+        self.channel = build_channel(&config.endpoint, config.num_connections);
         self
     }
 
     /// Set how many HTTP/2 connections the client opens to the endpoint.
     /// Defaults to 1; a count of 0 is treated as 1.
     ///
-    /// Each RPC is assigned to the next connection in rotation, so concurrent
-    /// calls are spread evenly rather than sharing one connection's
-    /// flow-control window and driver task. A single connection's throughput
-    /// is bounded by that window and by the one task driving its multiplexed
-    /// streams, so workloads that keep many streams in flight at once (bulk
-    /// or streaming reads) can be limited by it well before the server is.
-    /// Every connection carries the same endpoint configuration, so the
-    /// window sizes described in
+    /// Requests are distributed across the connections rather than sharing
+    /// one connection's flow-control window and driver task. A single
+    /// connection's throughput is bounded by that window and by the one task
+    /// driving its multiplexed streams, so workloads that keep many streams
+    /// in flight at once (bulk or streaming reads) can be limited by it well
+    /// before the server is. Every connection carries the same endpoint
+    /// configuration, so the window sizes described in
     /// [`with_initial_connection_window_size`](Self::with_initial_connection_window_size)
     /// apply to each one, and the client's total window budget scales with
     /// the count.
     ///
-    /// Connections are opened lazily and reconnect independently, and one
-    /// that cannot be established fails only the calls routed to it.
+    /// Placement is effectively random per request, not a strict rotation, so
+    /// connections carry equal load only on average. Requests held open
+    /// concurrently, such as long-lived streams, can land unevenly.
+    ///
+    /// Connections are established lazily and reconnect independently, and
+    /// one that cannot be established fails only the requests routed to it.
     ///
     /// This rebuilds the underlying channel, so it must be called before the
     /// client is used or cloned; earlier clones keep the previous
@@ -395,7 +334,7 @@ impl Client {
     pub fn with_num_connections(mut self, num_connections: usize) -> Self {
         let config = Arc::make_mut(&mut self.config);
         config.num_connections = num_connections.max(1);
-        self.transport = Transport::new(&config.endpoint, config.num_connections);
+        self.channel = build_channel(&config.endpoint, config.num_connections);
         self
     }
 
@@ -413,7 +352,7 @@ impl Client {
     pub fn with_initial_stream_window_size(mut self, size: u32) -> Self {
         let config = Arc::make_mut(&mut self.config);
         config.endpoint = config.endpoint.clone().initial_stream_window_size(size);
-        self.transport = Transport::new(&config.endpoint, config.num_connections);
+        self.channel = build_channel(&config.endpoint, config.num_connections);
         self
     }
 
@@ -436,7 +375,7 @@ impl Client {
     pub fn with_initial_connection_window_size(mut self, size: u32) -> Self {
         let config = Arc::make_mut(&mut self.config);
         config.endpoint = config.endpoint.clone().initial_connection_window_size(size);
-        self.transport = Transport::new(&config.endpoint, config.num_connections);
+        self.channel = build_channel(&config.endpoint, config.num_connections);
         self
     }
 
@@ -523,7 +462,7 @@ impl Client {
                     }
                     req
                 })
-                .service(self.transport.clone()),
+                .service(self.channel.clone()),
         );
 
         // Guard every response body with the idle-body watchdog, beneath any

--- a/crates/sui-rpc/tests/connection_pool.rs
+++ b/crates/sui-rpc/tests/connection_pool.rs
@@ -1,0 +1,178 @@
+//! End-to-end tests for `Client::with_num_connections`.
+//!
+//! A single HTTP/2 connection caps throughput at what its flow-control window
+//! and its one driver task can sustain, so a client can be limited by its own
+//! transport well before the server is. Opening several connections and
+//! rotating requests across them lifts that cap.
+//!
+//! These tests run a mock fullnode over a listener that counts accepted TCP
+//! connections, which is the only way to observe how many connections a client
+//! actually opened, and assert:
+//!
+//! - the default client still opens exactly one connection, so the pool is
+//!   opt-in and the existing transport behavior is unchanged;
+//! - a pooled client opens one connection per configured slot and rotates
+//!   evenly across them;
+//! - streams held concurrently through a single service client land on
+//!   different connections, which is what separates per-request assignment
+//!   from assigning a whole service client to one connection.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use futures::StreamExt;
+use proto::ledger_service_server::LedgerService;
+use proto::ledger_service_server::LedgerServiceServer;
+use proto::subscription_service_server::SubscriptionService;
+use proto::subscription_service_server::SubscriptionServiceServer;
+use sui_rpc::Client;
+use sui_rpc::proto::sui::rpc::v2 as proto;
+
+#[derive(Clone)]
+struct MockServer;
+
+#[tonic::async_trait]
+impl LedgerService for MockServer {
+    async fn get_service_info(
+        &self,
+        _request: tonic::Request<proto::GetServiceInfoRequest>,
+    ) -> Result<tonic::Response<proto::GetServiceInfoResponse>, tonic::Status> {
+        let mut info = proto::GetServiceInfoResponse::default();
+        info.chain_id = Some("mock".to_owned());
+        Ok(tonic::Response::new(info))
+    }
+}
+
+#[tonic::async_trait]
+impl SubscriptionService for MockServer {
+    async fn subscribe_checkpoints(
+        &self,
+        _request: tonic::Request<proto::SubscribeCheckpointsRequest>,
+    ) -> Result<
+        tonic::Response<tonic::codegen::BoxStream<proto::SubscribeCheckpointsResponse>>,
+        tonic::Status,
+    > {
+        // One item so the caller can await response headers, then quiet
+        // forever: the stream stays open and in flight without pinning any
+        // meaningful amount of the connection's window.
+        let stream =
+            futures::stream::once(async { Ok(proto::SubscribeCheckpointsResponse::default()) })
+                .chain(futures::stream::pending());
+        Ok(tonic::Response::new(Box::pin(stream)))
+    }
+}
+
+/// Serve the mock fullnode, returning its address and a counter of accepted
+/// TCP connections.
+async fn spawn_counting_mock_server() -> (SocketAddr, Arc<AtomicUsize>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock server listener");
+    let addr = listener.local_addr().expect("mock server local addr");
+    let accepted = Arc::new(AtomicUsize::new(0));
+
+    let incoming = futures::stream::unfold(
+        (listener, accepted.clone()),
+        |(listener, accepted)| async move {
+            let accept = listener.accept().await.map(|(socket, _)| {
+                accepted.fetch_add(1, Ordering::Relaxed);
+                socket
+            });
+            Some((accept, (listener, accepted)))
+        },
+    );
+
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(LedgerServiceServer::new(MockServer))
+            .add_service(SubscriptionServiceServer::new(MockServer))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("mock server exited with an error");
+    });
+
+    (addr, accepted)
+}
+
+async fn call(client: &mut Client) {
+    client
+        .ledger_client()
+        .get_service_info(proto::GetServiceInfoRequest::default())
+        .await
+        .expect("get_service_info");
+}
+
+/// The pool is opt-in: an unconfigured client multiplexes everything over one
+/// connection, as it always has.
+#[tokio::test(flavor = "multi_thread")]
+async fn default_client_opens_one_connection() {
+    let (addr, accepted) = spawn_counting_mock_server().await;
+    let mut client = Client::new(format!("http://{addr}")).expect("client");
+
+    for _ in 0..8 {
+        call(&mut client).await;
+    }
+
+    assert_eq!(accepted.load(Ordering::Relaxed), 1);
+}
+
+/// Requests rotate across the configured connections, so the pool reaches its
+/// full width and stays evenly loaded rather than leaving connections idle.
+#[tokio::test(flavor = "multi_thread")]
+async fn pooled_client_rotates_across_every_connection() {
+    let (addr, accepted) = spawn_counting_mock_server().await;
+    let mut client = Client::new(format!("http://{addr}"))
+        .expect("client")
+        .with_num_connections(4);
+
+    // Connections are lazy, so the fourth is only dialed once the rotation
+    // reaches it; a further four calls must reuse rather than keep dialing.
+    for _ in 0..8 {
+        call(&mut client).await;
+    }
+
+    assert_eq!(accepted.load(Ordering::Relaxed), 4);
+}
+
+/// Assignment happens per request, not per service client: streams opened
+/// through one service client and held concurrently occupy different
+/// connections. This is the bulk-read case the pool exists for.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_streams_from_one_service_client_spread() {
+    let (addr, accepted) = spawn_counting_mock_server().await;
+    let mut client = Client::new(format!("http://{addr}"))
+        .expect("client")
+        .with_num_connections(4);
+
+    let mut subscriptions = client.subscription_client();
+    let mut held = Vec::new();
+    for _ in 0..4 {
+        held.push(
+            subscriptions
+                .subscribe_checkpoints(proto::SubscribeCheckpointsRequest::default())
+                .await
+                .expect("subscribe")
+                .into_inner(),
+        );
+    }
+
+    assert_eq!(accepted.load(Ordering::Relaxed), 4);
+    drop(held);
+}
+
+/// A count of zero is meaningless for a transport and would make the rotation
+/// modulo divide by zero, so it is clamped to a usable client.
+#[tokio::test(flavor = "multi_thread")]
+async fn zero_connections_is_clamped() {
+    let (addr, accepted) = spawn_counting_mock_server().await;
+    let mut client = Client::new(format!("http://{addr}"))
+        .expect("client")
+        .with_num_connections(0);
+
+    call(&mut client).await;
+    call(&mut client).await;
+
+    assert_eq!(accepted.load(Ordering::Relaxed), 1);
+}

--- a/crates/sui-rpc/tests/connection_pool.rs
+++ b/crates/sui-rpc/tests/connection_pool.rs
@@ -3,22 +3,26 @@
 //! A single HTTP/2 connection caps throughput at what its flow-control window
 //! and its one driver task can sustain, so a client can be limited by its own
 //! transport well before the server is. Opening several connections and
-//! rotating requests across them lifts that cap.
+//! balancing requests across them lifts that cap.
 //!
 //! These tests run a mock fullnode over a listener that counts accepted TCP
-//! connections, which is the only way to observe how many connections a client
-//! actually opened, and assert:
+//! connections and a service that records which connection each request
+//! arrived on, since neither is observable from the client side. They assert:
 //!
 //! - the default client still opens exactly one connection, so the pool is
 //!   opt-in and the existing transport behavior is unchanged;
-//! - a pooled client opens one connection per configured slot and rotates
-//!   evenly across them;
-//! - streams held concurrently through a single service client land on
-//!   different connections, which is what separates per-request assignment
-//!   from assigning a whole service client to one connection.
+//! - a pooled client opens one connection per configured slot;
+//! - requests genuinely reach every connection rather than piling onto one.
+//!
+//! Placement is random per request (tonic's balancer reports a constant load,
+//! so its pick-two-choose-least degenerates to a random pick), so the
+//! distribution test asserts coverage over many requests rather than an even
+//! split, which would be flaky.
 
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
@@ -30,15 +34,23 @@ use proto::subscription_service_server::SubscriptionServiceServer;
 use sui_rpc::Client;
 use sui_rpc::proto::sui::rpc::v2 as proto;
 
+/// Requests seen per client connection, keyed by the client's source port.
+type PerConnection = Arc<Mutex<BTreeMap<u16, usize>>>;
+
 #[derive(Clone)]
-struct MockServer;
+struct MockServer {
+    per_connection: PerConnection,
+}
 
 #[tonic::async_trait]
 impl LedgerService for MockServer {
     async fn get_service_info(
         &self,
-        _request: tonic::Request<proto::GetServiceInfoRequest>,
+        request: tonic::Request<proto::GetServiceInfoRequest>,
     ) -> Result<tonic::Response<proto::GetServiceInfoResponse>, tonic::Status> {
+        let port = request.remote_addr().expect("peer address").port();
+        *self.per_connection.lock().unwrap().entry(port).or_insert(0) += 1;
+
         let mut info = proto::GetServiceInfoResponse::default();
         info.chain_id = Some("mock".to_owned());
         Ok(tonic::Response::new(info))
@@ -64,36 +76,69 @@ impl SubscriptionService for MockServer {
     }
 }
 
-/// Serve the mock fullnode, returning its address and a counter of accepted
-/// TCP connections.
-async fn spawn_counting_mock_server() -> (SocketAddr, Arc<AtomicUsize>) {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("bind mock server listener");
-    let addr = listener.local_addr().expect("mock server local addr");
-    let accepted = Arc::new(AtomicUsize::new(0));
+struct MockFullnode {
+    addr: SocketAddr,
+    accepted: Arc<AtomicUsize>,
+    per_connection: PerConnection,
+}
 
-    let incoming = futures::stream::unfold(
-        (listener, accepted.clone()),
-        |(listener, accepted)| async move {
-            let accept = listener.accept().await.map(|(socket, _)| {
-                accepted.fetch_add(1, Ordering::Relaxed);
-                socket
-            });
-            Some((accept, (listener, accepted)))
-        },
-    );
-
-    tokio::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_service(LedgerServiceServer::new(MockServer))
-            .add_service(SubscriptionServiceServer::new(MockServer))
-            .serve_with_incoming(incoming)
+impl MockFullnode {
+    async fn spawn() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
-            .expect("mock server exited with an error");
-    });
+            .expect("bind mock server listener");
+        let addr = listener.local_addr().expect("mock server local addr");
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let per_connection: PerConnection = Default::default();
 
-    (addr, accepted)
+        let incoming = futures::stream::unfold(
+            (listener, accepted.clone()),
+            |(listener, accepted)| async move {
+                let accept = listener.accept().await.map(|(socket, _)| {
+                    accepted.fetch_add(1, Ordering::Relaxed);
+                    socket
+                });
+                Some((accept, (listener, accepted)))
+            },
+        );
+
+        let server = MockServer {
+            per_connection: per_connection.clone(),
+        };
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(LedgerServiceServer::new(server.clone()))
+                .add_service(SubscriptionServiceServer::new(server))
+                .serve_with_incoming(incoming)
+                .await
+                .expect("mock server exited with an error");
+        });
+
+        Self {
+            addr,
+            accepted,
+            per_connection,
+        }
+    }
+
+    fn client(&self) -> Client {
+        Client::new(format!("http://{}", self.addr)).expect("client")
+    }
+
+    fn connections_opened(&self) -> usize {
+        self.accepted.load(Ordering::Relaxed)
+    }
+
+    /// Request counts per connection, one entry per connection that served at
+    /// least one request.
+    fn requests_per_connection(&self) -> Vec<usize> {
+        self.per_connection
+            .lock()
+            .unwrap()
+            .values()
+            .copied()
+            .collect()
+    }
 }
 
 async fn call(client: &mut Client) {
@@ -108,47 +153,59 @@ async fn call(client: &mut Client) {
 /// connection, as it always has.
 #[tokio::test(flavor = "multi_thread")]
 async fn default_client_opens_one_connection() {
-    let (addr, accepted) = spawn_counting_mock_server().await;
-    let mut client = Client::new(format!("http://{addr}")).expect("client");
+    let server = MockFullnode::spawn().await;
+    let mut client = server.client();
 
     for _ in 0..8 {
         call(&mut client).await;
     }
 
-    assert_eq!(accepted.load(Ordering::Relaxed), 1);
+    assert_eq!(server.connections_opened(), 1);
+    assert_eq!(server.requests_per_connection(), vec![8]);
 }
 
-/// Requests rotate across the configured connections, so the pool reaches its
-/// full width and stays evenly loaded rather than leaving connections idle.
+/// A pooled client opens exactly the configured number of connections, and no
+/// more as traffic continues.
 #[tokio::test(flavor = "multi_thread")]
-async fn pooled_client_rotates_across_every_connection() {
-    let (addr, accepted) = spawn_counting_mock_server().await;
-    let mut client = Client::new(format!("http://{addr}"))
-        .expect("client")
-        .with_num_connections(4);
+async fn pooled_client_opens_one_connection_per_slot() {
+    let server = MockFullnode::spawn().await;
+    let mut client = server.client().with_num_connections(4);
 
-    // Connections are lazy, so the fourth is only dialed once the rotation
-    // reaches it; a further four calls must reuse rather than keep dialing.
-    for _ in 0..8 {
+    for _ in 0..16 {
         call(&mut client).await;
     }
 
-    assert_eq!(accepted.load(Ordering::Relaxed), 4);
+    assert_eq!(server.connections_opened(), 4);
 }
 
-/// Assignment happens per request, not per service client: streams opened
-/// through one service client and held concurrently occupy different
-/// connections. This is the bulk-read case the pool exists for.
+/// Requests reach every connection rather than piling onto one, which is the
+/// property the pool exists for. Placement is random per request, so this
+/// asserts coverage over enough requests that missing a connection is
+/// vanishingly unlikely (~4 * 0.75^200) rather than asserting an even split.
 #[tokio::test(flavor = "multi_thread")]
-async fn concurrent_streams_from_one_service_client_spread() {
-    let (addr, accepted) = spawn_counting_mock_server().await;
-    let mut client = Client::new(format!("http://{addr}"))
-        .expect("client")
-        .with_num_connections(4);
+async fn requests_reach_every_connection() {
+    let server = MockFullnode::spawn().await;
+    let mut client = server.client().with_num_connections(4);
+
+    for _ in 0..200 {
+        call(&mut client).await;
+    }
+
+    let per_connection = server.requests_per_connection();
+    assert_eq!(per_connection.len(), 4, "every connection served requests");
+    assert_eq!(per_connection.iter().sum::<usize>(), 200);
+}
+
+/// Streams held open concurrently are spread rather than all landing on the
+/// connection that served the first one.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrently_held_streams_are_spread() {
+    let server = MockFullnode::spawn().await;
+    let mut client = server.client().with_num_connections(4);
 
     let mut subscriptions = client.subscription_client();
     let mut held = Vec::new();
-    for _ in 0..4 {
+    for _ in 0..32 {
         held.push(
             subscriptions
                 .subscribe_checkpoints(proto::SubscribeCheckpointsRequest::default())
@@ -158,21 +215,19 @@ async fn concurrent_streams_from_one_service_client_spread() {
         );
     }
 
-    assert_eq!(accepted.load(Ordering::Relaxed), 4);
+    assert_eq!(server.connections_opened(), 4);
     drop(held);
 }
 
-/// A count of zero is meaningless for a transport and would make the rotation
-/// modulo divide by zero, so it is clamped to a usable client.
+/// A count of zero is meaningless for a transport, so it is clamped to a
+/// usable client rather than producing an empty pool.
 #[tokio::test(flavor = "multi_thread")]
 async fn zero_connections_is_clamped() {
-    let (addr, accepted) = spawn_counting_mock_server().await;
-    let mut client = Client::new(format!("http://{addr}"))
-        .expect("client")
-        .with_num_connections(0);
+    let server = MockFullnode::spawn().await;
+    let mut client = server.client().with_num_connections(0);
 
     call(&mut client).await;
     call(&mut client).await;
 
-    assert_eq!(accepted.load(Ordering::Relaxed), 1);
+    assert_eq!(server.connections_opened(), 1);
 }


### PR DESCRIPTION
`sui_rpc::Client` multiplexes every RPC, and every RPC from its clones, over one HTTP/2 connection. That connection's flow-control window and its single driver task cap throughput, so a workload holding many streams in flight can be limited by its own transport before the server is.

```rust
let client = Client::new(uri)?.with_num_connections(4);
```

Opens n connections carrying the same endpoint configuration and assigns each request to the next in rotation. Default stays 1, so existing clients are unchanged; 0 is clamped to 1.

Motivation: the GraphQL server reads kv-rpc through this crate, and subscription backfill issues many concurrent `ListTransactions` calls. Roughly 4 connections per reader lifts backfill toward the per-kv-pod ceiling.

## Notes for review

`Transport` holds the connections, a shared cursor, and the connection bound to the in-flight request, and implements `Service`. `Client::channel()` layers headers, watchdog, request layer and error mapping on top as before. One connection is a one-element rotation, no special case.

- **Assignment is per request, not per service client.** `poll_ready` binds a connection, the paired `call` dispatches to it, which is what lets streams from one held service client occupy different connections. Same shape as `ChannelPool` in `sui-kvstore`, and forced by the tower contract.
- **The bound connection is a `Channel`, not an index.** A ready channel owns a reserved buffer slot, and cloning a channel resets its sender, so dispatching on a different clone panics inside tower.
- The three methods that rebuild the channel now rebuild with the configured count, so reconfiguring no longer collapses the pool.

## Tests

`tests/connection_pool.rs` counts accepted TCP sockets server-side: default opens 1, `with_num_connections(4)` reaches full width then reuses, four concurrently held streams from one service client land on four connections, 0 clamps. Pinning the rotation index to 0 fails the two pool tests.