### PR TITLE
fix(graphql): terminate trailing file comments

### DIFF
--- a/crates/sui-graphql-macros/src/lib.rs
+++ b/crates/sui-graphql-macros/src/lib.rs
@@ -338,8 +338,10 @@ pub fn derive_query_response(input: TokenStream) -> TokenStream {
 /// One or more sources can be supplied. An inline source is a string literal;
 /// prefix a path with `@` to load it from a UTF-8 file relative to the Rust
 /// source file containing the macro invocation. Sources are concatenated in
-/// order before the complete document is validated, allowing operations and
-/// fragments to be kept separately:
+/// order before the complete document is validated. File sources are terminated
+/// with a newline so trailing comments cannot consume the next source; inline
+/// literals are concatenated verbatim. This allows operations and fragments to
+/// be kept separately:
 ///
 /// ```ignore
 /// const QUERY: &str = graphql_query!(

--- a/crates/sui-graphql-macros/src/query.rs
+++ b/crates/sui-graphql-macros/src/query.rs
@@ -13,7 +13,6 @@
 //! inside a `ValidatedQuery` constructor, but this proc macro itself has no
 //! dependency on or knowledge of that type.
 
-use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
@@ -146,14 +145,15 @@ fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
         ));
     }
 
-    // Concatenate exactly like Rust's `concat!`: callers can split a document
-    // wherever they like, and fragments can live in separate sources. The
-    // complete document is still parsed, validated, and formatted as one unit.
-    let mut source = String::new();
+    // Concatenate inline literals exactly like Rust's `concat!`, so callers
+    // can even split tokens. Terminate file sources with a newline to keep
+    // trailing comments from swallowing the next source. Parse, validate,
+    // and format the complete document as one unit.
+    let mut query = String::new();
     let mut dependencies = Vec::new();
-    for input in sources {
-        match input {
-            Source::Inline(literal) => source.push_str(&literal.value()),
+    for source in sources {
+        match source {
+            Source::Inline(literal) => query.push_str(&literal.value()),
             Source::File(literal) => {
                 let path = source_relative(&literal)?;
                 let contents = std::fs::read_to_string(&path).map_err(|error| {
@@ -166,7 +166,9 @@ fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
                     )
                 })?;
 
-                source.push_str(&contents);
+                query.push_str(&contents);
+                query.push('\n');
+
                 dependencies.push(literal);
             }
         }
@@ -176,8 +178,8 @@ fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
         .as_ref()
         .map_err(|error| syn::Error::new(proc_macro2::Span::call_site(), error.clone()))?;
 
-    let document = ExecutableDocument::parse(source.as_str()).map_err(|errors| {
-        combine_query_errors(source.as_str(), errors).unwrap_or_else(|| {
+    let document = ExecutableDocument::parse(query.as_str()).map_err(|errors| {
+        combine_query_errors(query.as_str(), errors).unwrap_or_else(|| {
             syn::Error::new(
                 proc_macro2::Span::call_site(),
                 "GraphQL parsing failed with no diagnostics",
@@ -187,7 +189,7 @@ fn expand_impl(input: TokenStream) -> Result<TokenStream2, syn::Error> {
 
     let cache = Cache::new(&document, schema);
     if let Some(error) = combine_query_errors(
-        source.as_str(),
+        query.as_str(),
         ExecutableValidator::validate(&document, schema, &cache),
     ) {
         return Err(error);
@@ -217,10 +219,9 @@ where
 
 /// Interpret `path` as a path relative to the source file containing the macro invocation.
 fn source_relative(literal: &LitStr) -> Result<PathBuf, syn::Error> {
-    let value = literal.value();
-    let path = Path::new(&value);
+    let path = PathBuf::from(literal.value());
     if path.is_absolute() {
-        return Ok(path.to_owned());
+        return Ok(path);
     }
 
     let source = literal.span().local_file();

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_empty.rs
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_empty.rs
@@ -1,0 +1,9 @@
+//! trybuild compile-fail: at least one GraphQL source is required.
+
+use sui_graphql_macros::graphql_query;
+
+const Q: &str = graphql_query!();
+
+fn main() {
+    let _ = Q;
+}

--- a/crates/sui-graphql-macros/tests/compile/graphql_query_empty.stderr
+++ b/crates/sui-graphql-macros/tests/compile/graphql_query_empty.stderr
@@ -1,0 +1,7 @@
+error: expected at least one GraphQL source
+ --> tests/compile/graphql_query_empty.rs:5:17
+  |
+5 | const Q: &str = graphql_query!();
+  |                 ^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the macro `graphql_query` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/sui-graphql-macros/tests/compile_tests.rs
+++ b/crates/sui-graphql-macros/tests/compile_tests.rs
@@ -60,6 +60,7 @@ fn compile_tests() {
     t.pass("tests/compile/graphql_query_with_variables.rs");
     t.pass("tests/compile/graphql_query_mutation.rs");
     t.pass("tests/compile/graphql_query_multiple_strings.rs");
+    t.compile_fail("tests/compile/graphql_query_empty.rs");
     t.compile_fail("tests/compile/graphql_query_unknown_field.rs");
     t.compile_fail("tests/compile/graphql_query_undefined_variable.rs");
     t.compile_fail("tests/compile/graphql_query_variable_typo.rs");

--- a/crates/sui-graphql-macros/tests/graphql_query_test.rs
+++ b/crates/sui-graphql-macros/tests/graphql_query_test.rs
@@ -15,3 +15,29 @@ fn file_sources_are_loaded_and_formatted() {
     assert_eq!(FILE_QUERY, MIXED_QUERY);
     assert!(FILE_QUERY.contains("chainIdentifier"));
 }
+
+#[test]
+fn file_comments_at_eof_are_terminated() {
+    // Keep the fixture without a final newline to exercise the source boundary.
+    assert!(
+        !include_str!("queries/chain_identifier_fragment_with_comment.graphql").ends_with('\n')
+    );
+
+    let expected = graphql_query!(
+        "fragment ChainIdentifier on Query { chainIdentifier }",
+        "query { ...ChainIdentifier }",
+    );
+
+    let followed_by_inline = graphql_query!(
+        @"queries/chain_identifier_fragment_with_comment.graphql",
+        "query { ...ChainIdentifier }",
+    );
+
+    let followed_by_file = graphql_query!(
+        @"queries/chain_identifier_fragment_with_comment.graphql",
+        @"queries/chain_identifier_query.graphql",
+    );
+
+    assert_eq!(followed_by_inline, expected);
+    assert_eq!(followed_by_file, expected);
+}

--- a/crates/sui-graphql-macros/tests/queries/chain_identifier_fragment_with_comment.graphql
+++ b/crates/sui-graphql-macros/tests/queries/chain_identifier_fragment_with_comment.graphql
@@ -1,0 +1,4 @@
+fragment ChainIdentifier on Query {
+    chainIdentifier
+}
+# Deliberately no newline at EOF.


### PR DESCRIPTION
## Description

Follow up on review feedback from #306. Trailing comments in GraphQL files without a final newline could consume the next source. Terminate file sources with a newline while keeping inline literals concatenated verbatim, including split tokens. Simplify source naming and path construction as requested.

## Test Plan

Added integration coverage for a file ending in a comment without a newline, followed by either an inline query or another file. Added a compile-fail test for `graphql_query!()` with no sources.
